### PR TITLE
Feature/add mqtt transport and clean up server lifecycle

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((rustic-mode
+  . ((rustic-analyzer-cargo-all-features . t))))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+      
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta]
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust ${{ matrix.rust }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ matrix.rust }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Test default features
+        run: cargo test --all-targets
+      
+      - name: Test all features
+        run: cargo test --all-targets --all-features
+      
+      - name: Test no default features
+        run: cargo test --all-targets --no-default-features
+      
+      - name: Test transport_mqttac only
+        run: cargo test --all-targets --no-default-features --features transport_mqttac
+      
+      - name: Test doc tests
+        run: cargo test --doc --all-features
+      
+      - name: Build examples
+        run: cargo build --examples --all-features
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
+      
+      - name: Run tarpaulin
+        run: cargo tarpaulin --all-features --workspace --timeout 300 --out xml
+      
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./cobertura.xml
+          fail_ci_if_error: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,31 +4,65 @@ Thanks for considering contributing!
 
 ## Quick Start
 
-This is a pure Rust library crate for RPC over MQTT. No cross-compilation or embedded targets required.
+This is a pure Rust library crate providing RPC semantics over message-oriented middleware (MOM). It supports multiple transport backends including in-memory (for testing) and MQTT. No cross-compilation or embedded targets required.
+
+### Cross-Compilation
+
+This library is cross-platform and suitable for embedded/edge deployments. Cross-compilation and platform-specific concerns are handled at the consuming crate level. Once this crate stabilizes, [rust-edge-agent](https://github.com/JohnBasrai/rust-edge-agent) will be refactored to use mom-rpc as a reference example for cross-compiled projects.
 
 ## Local Development
 
-### Starting MQTT Broker
+### Running the Memory Transport Example
 
-Before running examples or tests:
+The quickest way to get started is with the in-memory transport (no broker needed):
 
 ```bash
-# Start mosquitto (MQTT v5 required)
+cargo run --example math_memory
+```
+
+This example demonstrates the full RPC lifecycle with client and server in a single process.
+
+### Running Unit Tests
+
+```bash
+# Run all unit tests
+cargo test --lib
+
+# Run all tests including integration tests
+cargo test
+```
+
+### Testing Feature Combinations
+
+This crate supports optional features. Test all combinations:
+
+```bash
+# Test with MQTT transport enabled
+cargo build --features transport_mqttac
+
+# Test minimal build (no default features)
+cargo build --no-default-features
+
+# Test with all features
+cargo build --all-features
+```
+
+### Working with Broker-Based Transports
+
+If you're developing or testing a broker-based transport (MQTT, AMQP, etc.):
+
+```bash
+# Start your broker (example for MQTT/mosquitto)
 ./scripts/start-mosquitto.sh
 
-# Or manually
-mosquitto -v
-```
-
-### Running Examples
-
-```bash
 # Terminal 1: Start server
-cargo run --example math_server
+cargo run --example math_server --features transport_mqttac
 
 # Terminal 2: Send requests
-cargo run --example math_client
+cargo run --example math_client --features transport_mqttac
 ```
+
+**Note:** The `math_server` and `math_client` examples require an external broker and cannot use the in-memory transport.
 
 ### Before Submitting a Pull Request
 
@@ -54,31 +88,58 @@ This project uses `rustfmt` for consistent code formatting.
 Since `rustfmt` removes blank lines at the start of impl blocks, function bodies, and module blocks, we use comment separators `// ---` for visual clarity:
 
 ```rust
-// Module blocks
-mod client {
+// Use blocks
+use crate::{
     // ---
-    use super::*;
-
-    pub fn send_request() {
-        // ---
-        // function body
-    }
-}
+    Address,
+    Envelope,
+    PublishOptions,
+    Result,
+};
 
 // Struct definitions
-pub struct RpcClient {
+struct MemoryTransport {
     // ---
-    mom_rpc: AsyncClient,
-    pending: Arc<Mutex<HashMap<CorrelationId, Sender>>>,
+    subscriptions: RwLock<HashMap<Subscription, Vec<mpsc::Sender<Envelope>>>>,
+    transport_id: String,
 }
 
 // Impl blocks
-impl RpcClient {
+#[async_trait::async_trait]
+impl Transport for MemoryTransport {
     // ---
-    pub async fn request<T>(&self, topic: &str, payload: T) {
-        // ---
-        // implementation
+    fn transport_id(&self) -> &str {
+        self.transport_id.as_str()
     }
+
+    async fn publish(&self, env: Envelope, _opts: PublishOptions) -> Result<()> {
+        // ---
+        let subs = self.subscriptions.read().await;
+
+        for (sub, senders) in subs.iter() {
+            if sub.0 == env.address.0 {
+                for sender in senders {
+                    sender.send(env.clone()).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Function definitions
+pub async fn create_transport(config: &RpcConfig) -> Result<TransportPtr> {
+    // ---
+    let transport_id = config.transport_id.clone();
+    
+    let transport = MemoryTransport {
+        // ---
+        transport_id,
+        subscriptions: RwLock::new(HashMap::new()),
+    };
+
+    Ok(Arc::new(transport))
 }
 
 // Test modules
@@ -88,7 +149,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_correlation_matching() {
+    async fn test_subscription_delivery() {
         // ---
         // test body
     }
@@ -96,10 +157,10 @@ mod tests {
 ```
 
 **Style Guidelines:**
-1. Use `// ---` for visual separation in **module blocks**, **impl blocks**, **struct definitions**, and **function bodies**
+1. Use `// ---` for visual separation in **use blocks**, **impl blocks**, **struct definitions**, and **function bodies**
 2. Place separators after the opening brace and before the first meaningful line
-3. Between meaningful steps of logic processing
-4. Do NOT use separators inside struct literals (during construction)
+3. Use between meaningful steps of logic processing within function bodies
+4. Do NOT use separators between fields in struct literals
 5. Keep separators consistent across the codebase
 
 ## Documentation and Doc Comments
@@ -119,40 +180,41 @@ Doc comments should describe **intent, guarantees, and failure semantics** — n
 
 ### RPC/Messaging-Specific Documentation
 
-For RPC and MQTT code, doc comments should explicitly describe:
+For RPC and messaging code, doc comments should explicitly describe:
 
-- **Failure modes** - What happens on timeout, connection loss, broker unavailable?
+- **Failure modes** - What happens on timeout, connection loss, transport unavailable?
 - **Message flow** - Which part of request/response cycle is this?
 - **Concurrency** - Can multiple requests be in-flight? How are handlers executed?
 - **Correlation semantics** - How are requests matched to responses?
+- **Transport behavior** - Does this depend on specific transport semantics?
 
 Example:
 ```rust
 /// Sends an RPC request and returns a Future that resolves when the response arrives.
 ///
-/// This method generates a unique correlation ID, subscribes to the response topic
-/// if not already subscribed, and publishes the request with MQTT v5 response_topic
-/// property set.
+/// This method generates a unique correlation ID, subscribes to the response address
+/// if not already subscribed, and publishes the request to the target service.
 ///
 /// # Behavior
 ///
 /// - Correlation ID: UUID v4 (36-byte string format)
-/// - Response topic: `responses/{client_id}`
-/// - Request published to: `{topic}/request`
+/// - Response address: `{service_name}/responses/{client_id}`
+/// - Request published to: `{service_name}/{method}`
 /// - Concurrent requests: Supported via internal HashMap tracking
 ///
 /// # Errors
 ///
 /// Returns an error if:
-/// - MQTT client is disconnected
+/// - Transport is disconnected
 /// - Request serialization fails
 /// - Publish fails
 ///
 /// # Timeouts
 ///
-/// Use `.timeout()` method on returned `RequestFuture` to add timeout handling.
-pub async fn request<Req, Resp>(&self, topic: &str, payload: &Req) 
-    -> Result<RequestFuture<Resp>>
+/// Timeouts are handled at the application layer. Consider using
+/// `tokio::time::timeout()` when awaiting the returned future.
+pub async fn request<Req, Resp>(&self, service: &str, method: &str, payload: &Req) 
+    -> Result<Resp>
 where
     Req: Serialize,
     Resp: DeserializeOwned,
@@ -204,56 +266,81 @@ This project uses the [Explicit Module Boundary Pattern (EMBP)](https://github.c
 src/
 ├── lib.rs            # Public API exports
 ├── error.rs          # Error types
-├── protocol/         # Correlation IDs and message types
-│   ├── mod.rs        # Gateway
-│   ├── correlation.rs
-│   └── message.rs
+├── rpc_config.rs     # Configuration
+├── correlation.rs    # Correlation ID handling
+├── domain/           # Domain types and traits
+│   ├── mod.rs        # Gateway: Transport trait, core types
+│   └── transport.rs  # Transport abstraction
 ├── client/           # RPC client
 │   ├── mod.rs        # Gateway: RpcClient
 │   └── pending.rs    # In-flight request tracking
-└── server/           # RPC server
-    ├── mod.rs        # Gateway: RpcServer
-    └── handler.rs    # Handler execution
+├── server/           # RPC server
+│   ├── mod.rs        # Gateway: RpcServer
+│   └── handler.rs    # Handler execution
+└── transport/        # Transport implementations
+    ├── mod.rs        # Transport factory
+    ├── memory/       # In-memory transport (always available)
+    │   ├── mod.rs
+    │   └── transport.rs
+    └── mqtt_async_client/  # MQTT transport (optional feature)
+        ├── mod.rs
+        └── transport.rs
 ```
 
 ## Test Coverage
 
-This project uses a **layered testing approach**:
+This project uses a **layered testing approach** with memory transport as the primary test backend.
 
 ### Current Test Strategy
 
-**Integration Tests:**
-- Full client ↔ server roundtrips with real MQTT broker
-- Timeout behavior and error handling
+**Unit Tests (Primary):**
+- Transport-agnostic RPC behavior using in-memory transport
+- Correlation ID generation and matching
+- Message serialization/deserialization
+- Error type conversions
 - Concurrent request handling
 - Handler execution and response matching
 
-**Unit Tests:**
-- Correlation ID generation
-- Message serialization/deserialization
-- Error type conversions
+**Integration Tests:**
+- Full client ↔ server roundtrips with memory transport
+- Timeout behavior and error handling
+- Multiple concurrent clients
+- Handler spawning and lifecycle
+
+**Broker-Based Tests (Optional):**
+- Real MQTT broker integration (when `transport_mqttac` feature is enabled)
+- Network failure scenarios
+- Cross-process communication
 
 ### When to Add Tests
 
-**Add integration tests when:**
-- Adding new RPC patterns
+**Add unit tests when:**
+- Adding new RPC patterns or features
 - Changing correlation or timeout logic
 - Modifying handler execution behavior
-
-**Add unit tests when:**
 - Complex logic needs isolated testing
-- Edge cases are difficult to trigger via integration tests
+
+**Add integration tests when:**
+- Testing full request/response cycles
+- Validating multi-client scenarios
+- Testing edge cases difficult to trigger via unit tests
+
+**Add broker-based tests when:**
+- Implementing a new transport backend
+- Testing transport-specific failure modes
+- Validating network behavior
 
 ### Test Organization
 
 ```
 tests/
-  integration.rs        # Full roundtrip tests with mosquitto
+  integration.rs           # Full roundtrip tests
+  transport_memory.rs      # Memory transport specific tests
 
 scripts/
-  ci-lint.sh            # Formatting and clippy
-  ci-test.sh            # All tests + examples
-  start-mosquitto.sh    # Start MQTT broker for testing
+  ci-lint.sh              # Formatting and clippy
+  ci-test.sh              # All tests + examples
+  start-mosquitto.sh      # Start MQTT broker (for MQTT transport testing)
 ```
 
 **Running tests:**
@@ -261,8 +348,11 @@ scripts/
 # Linting
 ./scripts/ci-lint.sh
 
-# All tests (requires mosquitto on localhost:1883)
-./scripts/ci-test.sh
+# All tests (memory transport, no broker needed)
+cargo test
+
+# Test specific features
+cargo test --features transport_mqttac
 
 # Just unit tests
 cargo test --lib
@@ -278,8 +368,10 @@ When testing RPC flows:
 - Test both successful and error responses
 - Verify timeout handling
 - Test concurrent requests from same client
-- Include tests for connection loss scenarios
+- Test multiple clients simultaneously
+- Include tests for transport disconnection scenarios
 - Validate correlation ID matching with multiple in-flight requests
+- For new transports: verify semantics match memory transport reference implementation
 
 ## Dependencies
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,23 @@ keywords = ["middleware", "pubsub", "rpc", "iot", "async", "messaging"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-bytes = "1"
-log = { version = "0.4", optional = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["full"] }
-url = "2"
-uuid = { version = "1.11", features = ["v4", "serde"] }
+anyhow            = "1.0"
+async-trait       = "0.1"
+bytes             = { version = "1", features = ["serde"] }
+futures           = { version = "0.3", optional = true }
+log               = { version = "0.4", optional = true }
+mqtt-async-client = { version = "0.3", optional = true }
+serde             = { version = "1", features = ["derive", "rc"] }
+serde_json        = "1"
+thiserror         = "2"
+tokio             = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+url               = "2"
+uuid              = { version  = "1.11", features = ["v4", "serde"] }
 
 [dev-dependencies]
 env_logger = "0.11"
 futures = "0.3.31"
+tokio = { version = "1", features = ["signal"] }
 tokio-test = "0.4"
 
 [[example]]
@@ -34,8 +37,8 @@ path = "examples/math_server.rs"
 name = "math_client"
 path = "examples/math_client.rs"
 
-
 [features]
 default = ["logging"]
 logging = ["log"]
-transport-mqtt-async-client = []
+transport_mqttac = ["mqtt-async-client"]
+transport_acme = []

--- a/examples/math_client.rs
+++ b/examples/math_client.rs
@@ -8,7 +8,7 @@
 //!
 //! Requires: a broker to be running
 
-use mom_rpc::{create_transport, RpcClient};
+use mom_rpc::{create_transport, RpcClient, RpcConfig};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -25,8 +25,9 @@ struct AddResponse {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // ---
-    // Transport will eventually be MQTT / Rabbit / etc.
-    let transport = create_transport("broker").await?;
+    let config = RpcConfig::with_broker("mqtt://localhost:1883", "math-client");
+
+    let transport = create_transport(&config).await?;
 
     let client = RpcClient::with_transport(transport.clone(), "client-1".to_string()).await?;
 

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
-# CI script for running tests
+# CI script for running tests with multiple feature combinations
 
 set -e
 
-echo "=== Running unit tests ==="
-cargo test --lib
+echo "=== Testing default features ==="
+cargo test --all-targets
 
 echo ""
-echo "=== Running integration tests ==="
-echo "NOTE: Requires mosquitto running on localhost:1883"
-cargo test --test integration
+echo "=== Testing all features ==="
+cargo test --all-targets --all-features
+
+echo ""
+echo "=== Testing no default features ==="
+cargo test --all-targets --no-default-features
+
+echo ""
+echo "=== Testing with transport_mqttac only ==="
+cargo test --all-targets --no-default-features --features transport_mqttac
 
 echo ""
 echo "=== Building examples ==="
-cargo build --examples
+cargo build --examples --all-features
+
+echo ""
+echo "=== Running doc tests ==="
+cargo test --doc --all-features
 
 echo ""
 echo "✅ All tests passed!"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -144,10 +144,10 @@ impl RpcClient {
     ///
     /// This calls `crate::create_transport()` (feature-driven) and then
     /// constructs the client using `with_transport()`.
-    pub async fn new(node_id: String) -> Result<Self> {
+    pub async fn new(config: &super::RpcConfig, node_id: &str) -> Result<Self> {
         // ---
-        let transport = crate::create_transport(&node_id).await?;
-        Self::with_transport(transport, node_id).await
+        let transport = crate::create_transport(config).await?;
+        Self::with_transport(transport, node_id.into()).await
     }
 
     /// Send an RPC request to a target service node.

--- a/src/domain/transport.rs
+++ b/src/domain/transport.rs
@@ -15,6 +15,7 @@
 //!
 //! Concrete implementations of this interface live under `src/transport/`.
 use crate::Result;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -31,7 +32,7 @@ use tokio::sync::mpsc;
 ///
 /// The domain layer makes no assumptions about address syntax, hierarchy,
 /// or wildcard behavior.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Address(pub Arc<str>);
 
 impl<T> From<T> for Address
@@ -83,7 +84,7 @@ where
 ///
 /// The transport layer does not interpret the payload or metadata fields;
 /// it is responsible only for delivery.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Envelope {
     // ---
     /// Delivery address used by the transport.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use error::{Error, Result};
 
 pub use transport::create_memory_transport;
 
-#[cfg(feature = "transport-mqtt-async-client")]
+#[cfg(feature = "transport_mqttac")]
 pub use transport::create_mqtt_async_client_transport;
 
 // --- public re-exports
@@ -43,21 +43,18 @@ pub use domain::{
     TransportPtr,
 };
 
-pub async fn create_transport(transport_id: &str) -> Result<TransportPtr> {
+pub async fn create_transport(config: &RpcConfig) -> Result<TransportPtr> {
     // ---
-    #[cfg(feature = "transport-mqtt-async-client")]
+    #[cfg(feature = "transport_mqttac")]
     {
-        create_mqtt_async_client_transport(transport_id).await
+        create_mqtt_async_client_transport(config).await
     }
 
     // Future transport impls go here
 
-    #[cfg(all(
-        not(feature = "transport-mqtt-async-client"),
-        //not(feature = "transport-rabbitmq")
-    ))]
+    #[cfg(all(not(feature = "transport_mqttac"), not(feature = "transport_acme")))]
     {
         // Fallback / default
-        create_memory_transport(transport_id).await
+        create_memory_transport(config).await
     }
 }

--- a/src/rpc_config.rs
+++ b/src/rpc_config.rs
@@ -12,22 +12,35 @@ pub struct RpcConfig {
     /// Keep-alive interval in seconds.
     ///
     /// If `None`, a sensible transport default is used.
-    pub keep_alive_secs: Option<u64>,
+    pub keep_alive_secs: Option<u16>,
+
+    /// The transport_id used by the transport end point.
+    pub transport_id: String,
 }
 
 impl RpcConfig {
     /// Create a new `RpcConfig` with the given broker address.
     ///
     /// Keep-alive will use the transport default.
-    pub fn new(broker_addr: impl Into<String>) -> Self {
+    pub fn with_broker(broker_addr: impl Into<String>, transport_id: impl Into<String>) -> Self {
         Self {
             broker_addr: broker_addr.into(),
             keep_alive_secs: None,
+            transport_id: transport_id.into(),
+        }
+    }
+
+    /// Create a memory transport config (no broker).
+    pub fn memory(transport_id: impl Into<String>) -> Self {
+        Self {
+            broker_addr: String::new(),
+            keep_alive_secs: None,
+            transport_id: transport_id.into(),
         }
     }
 
     /// Set an explicit keep-alive interval.
-    pub fn with_keep_alive_secs(mut self, secs: u64) -> Self {
+    pub fn with_keep_alive_secs(mut self, secs: u16) -> Self {
         self.keep_alive_secs = Some(secs);
         self
     }

--- a/src/transport/memory/mod.rs
+++ b/src/transport/memory/mod.rs
@@ -28,5 +28,4 @@
 
 mod transport;
 
-use super::SubscriptionManager;
 pub use transport::create_transport;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -6,16 +6,13 @@
 //!
 //! Domain code must not depend on transport-specific types.
 
-mod common;
 mod memory;
 
-#[cfg(feature = "transport-mqtt-async-client")]
+#[cfg(feature = "transport_mqttac")]
 mod mqtt_async_client;
 
-#[cfg(feature = "transport-mqtt-async-client")]
+#[cfg(feature = "transport_mqttac")]
 pub use mqtt_async_client::create_transport as create_mqtt_async_client_transport;
 
 #[allow(unused)]
 pub use memory::create_transport as create_memory_transport;
-
-use common::SubscriptionManager;

--- a/src/transport/mqtt_async_client/mod.rs
+++ b/src/transport/mqtt_async_client/mod.rs
@@ -4,6 +4,4 @@
 //! `Transport` trait without leaking MQTT concepts upward.
 
 mod transport;
-
-use super::SubscriptionManager;
 pub use transport::create_transport;

--- a/src/transport/mqtt_async_client/transport.rs
+++ b/src/transport/mqtt_async_client/transport.rs
@@ -1,12 +1,74 @@
+//! MQTT transport implementation using `mqtt_async_client`.
+//!
+//! This module provides an implementation of the `Transport` trait backed by
+//! an MQTT broker connection. It follows an **actor-based concurrency model**
+//! to safely integrate with the underlying MQTT client, which is `Send` but
+//! explicitly **not `Sync`** and requires mutable access for receiving messages.
+//!
+//! ## Concurrency model
+//!
+//! - A single background **actor task** owns the MQTT `Client`.
+//! - The actor is responsible for:
+//!   - publishing outbound messages,
+//!   - registering broker subscriptions,
+//!   - reading inbound publishes via `read_subscriptions()`,
+//!   - clean shutdown of the connection.
+//! - All interaction with the MQTT client is serialized through this actor;
+//!   no other task ever touches the client directly.
+//!
+//! This design preserves the public `Transport` contract (`Send + Sync`) while
+//! respecting the MQTT client’s internal mutability and state-machine semantics.
+//!
+//! ## Message delivery semantics
+//!
+//! Incoming MQTT publishes are **demultiplexed by topic** and **fanned out**
+//! to all local subscribers registered for that topic, matching the memory
+//! transport contract:
+//!
+//! - Fanout delivers messages to *all* subscribers.
+//! - Delivery is best-effort and non-durable.
+//! - There is no replay, persistence, or retained-message support.
+//!
+//! Each call to `subscribe()` registers a new local inbox channel. Multiple
+//! subscribers for the same topic are supported.
+//!
+//! ## Scope and limitations
+//!
+//! - One transport instance corresponds to a single broker connection.
+//! - The transport assumes a small number of active topics and subscribers
+//!   (typical RPC-style usage).
+//! - Text-based payloads (JSON) are decoded in the actor before fanout; payload
+//!   parsing cost dominates over synchronization overhead.
+//!
+//! This module intentionally avoids exposing MQTT-specific concepts (QoS,
+//! retain flags, session state) outside the transport boundary.
+//! MQTT transport implementation using `mqtt_async_client`.
+//!
+//! See module-level documentation for architecture and concurrency semantics.
+
+use mqtt_async_client::client::{
+    //
+    Client,
+    KeepAlive,
+    Publish,
+    QoS,
+    Subscribe,
+    SubscribeTopic,
+};
+
+use std::collections::HashMap;
 use std::sync::Arc;
 
-#[allow(unused_imports)]
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::task::JoinHandle;
+
 use crate::{
     //
-    Address,
     Envelope,
+    Error,
     PublishOptions,
     Result,
+    RpcConfig,
     SubscribeOptions,
     Subscription,
     SubscriptionHandle,
@@ -14,37 +76,290 @@ use crate::{
     TransportPtr,
 };
 
-use super::SubscriptionManager;
+//
+// Logging macros (transport-local for now; intended to be shared later)
+//
 
-/// Concrete Transport backed by mqtt-async-client.
-///
-/// All MQTT-specific concerns (topics, client state, callbacks, etc.)
-/// are contained within this type.
-struct MqttAsyncClientTransport {
+macro_rules! log_debug {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "logging")]
+        log::debug!($($arg)*);
+    };
+}
+
+macro_rules! log_error {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "logging")]
+        log::error!($($arg)*);
+    };
+}
+
+type SubscriberMap = Arc<RwLock<HashMap<String, Vec<mpsc::Sender<Envelope>>>>>;
+type TaskList = Arc<RwLock<Vec<JoinHandle<()>>>>;
+
+//
+// Actor commands
+//
+
+enum Cmd {
+    Publish {
+        env: Envelope,
+        resp: oneshot::Sender<Result<()>>,
+    },
+    Subscribe {
+        topic: String,
+        resp: oneshot::Sender<Result<()>>,
+    },
+    Close {
+        resp: oneshot::Sender<Result<()>>,
+    },
+}
+
+enum ActorStep {
+    Continue,
+    Stop,
+}
+
+impl Cmd {
     // ---
+
+    /// Dispatches an actor command to the correct handler on the actor
+    async fn handle(self, actor: &mut MqttActor) -> ActorStep {
+        // ---
+
+        match self {
+            Cmd::Publish { env, resp } => {
+                actor.handle_publish(env).await;
+                let _ = resp.send(Ok(()));
+                ActorStep::Continue
+            }
+            Cmd::Subscribe { topic, resp } => {
+                actor.handle_subscribe(topic).await;
+                let _ = resp.send(Ok(()));
+                ActorStep::Continue
+            }
+            Cmd::Close { resp } => {
+                actor.handle_close().await;
+                let _ = resp.send(Ok(()));
+                ActorStep::Stop
+            }
+        }
+    }
+}
+
+/// MQTT-based implementation of the `Transport` trait.
+///
+/// Represents a single broker connection and provides best-effort,
+/// non-durable message delivery consistent with memory transport semantics.
+pub struct MqttAsyncClientTransport {
     transport_id: String,
-    subscriptions: SubscriptionManager,
+    cmd_tx: mpsc::Sender<Cmd>,
+    subscribers: SubscriberMap,
+    tasks: TaskList,
+}
+
+impl MqttAsyncClientTransport {
+    //---
+
+    pub fn creat(transport_id: impl Into<String>, client: Client) -> TransportPtr {
+        // ---
+        let transport_id = transport_id.into();
+
+        let (cmd_tx, cmd_rx) = mpsc::channel(64);
+        let subscribers = Arc::new(RwLock::new(HashMap::new()));
+        let tasks = Arc::new(RwLock::new(Vec::new()));
+
+        let actor = MqttActor {
+            _transport_id: transport_id.clone(),
+            client,
+            cmd_rx,
+            subscribers: Arc::clone(&subscribers),
+        };
+
+        let handle = tokio::spawn(actor.run());
+        let tasks_clone = Arc::clone(&tasks);
+
+        tokio::spawn(async move {
+            tasks_clone.write().await.push(handle);
+        });
+
+        Arc::new(Self {
+            transport_id,
+            cmd_tx,
+            subscribers,
+            tasks,
+        })
+    }
+}
+
+struct MqttActor {
+    _transport_id: String, // for logging only
+    client: Client,
+    cmd_rx: mpsc::Receiver<Cmd>,
+    subscribers: SubscriberMap,
+}
+
+impl MqttActor {
+    // ---
+
+    async fn run(mut self) {
+        // ---
+
+        loop {
+            tokio::select! {
+                cmd = self.cmd_rx.recv() => {
+                    match cmd {
+                        Some(cmd) => {
+                            if matches!(cmd.handle(&mut self).await, ActorStep::Stop) {
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+
+                read = self.client.read_subscriptions() => {
+                    match read {
+                        Ok(rr) => {
+                            self.handle_incoming(rr.topic(), rr.payload()).await;
+                        }
+                        Err(_err) => {
+                            log_debug!(
+                                "{}: error reading subscription: {_err}",
+                                self._transport_id
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_publish(&mut self, env: Envelope) {
+        // ---
+        let topic = env.address.0.as_ref();
+
+        let payload = match serde_json::to_vec(&env) {
+            Ok(p) => p,
+            Err(_err) => {
+                log_error!(
+                    "{}: failed to serialize publish payload: {_err}",
+                    self._transport_id
+                );
+                return;
+            }
+        };
+
+        let mut publish = Publish::new(topic.into(), payload);
+        publish.set_qos(QoS::AtMostOnce).set_retain(false);
+
+        if let Err(_err) = self.client.publish(&publish).await {
+            log_error!(
+                "{}: publish failed for topic {topic}: {_err}",
+                self._transport_id
+            );
+        }
+    }
+
+    async fn handle_subscribe(&mut self, topic: String) {
+        // ---
+        let subscribe = Subscribe::new(vec![SubscribeTopic {
+            topic_path: topic.clone(),
+            qos: QoS::AtMostOnce,
+        }]);
+
+        if let Err(_err) = self.client.subscribe(subscribe).await {
+            log_error!(
+                "{}: broker subscribe failed for topic {topic}: {_err}",
+                self._transport_id
+            );
+        }
+    }
+
+    async fn handle_close(&mut self) {
+        // ---
+        log_debug!("{}: disconnecting mqtt client", self._transport_id);
+
+        if let Err(_err) = self.client.disconnect().await {
+            log_debug!("{}: mqtt disconnect failed: {_err}", self._transport_id);
+        }
+    }
+
+    async fn handle_incoming(&self, topic: &str, payload: &[u8]) {
+        // ---
+        let env = match serde_json::from_slice::<Envelope>(payload) {
+            Ok(env) => env,
+            Err(_err) => {
+                log_debug!(
+                    "{}: invalid envelope on topic {topic}: {_err}",
+                    self._transport_id
+                );
+                return;
+            }
+        };
+
+        let senders = {
+            let map = self.subscribers.read().await;
+            map.get(topic).cloned()
+        };
+
+        let Some(senders) = senders else {
+            // No subscribers for this topic
+            return;
+        };
+
+        // Snapshot the original subscriber count before consuming `senders`.
+        // We move `senders` below to retain ownership of live senders, so we
+        // must capture any metadata we still need up front.
+        let original_len = senders.len();
+
+        // Collect only the surviving (live) subscribers.
+        // `Sender` is cheap to move/clone; we rebuild the list to evict
+        // closed or backpressured subscribers.
+        let mut survivors = Vec::with_capacity(original_len);
+
+        // Consume `senders` so we keep owned `Sender` values.
+        // Iterating by value avoids storing references back into the map.
+        for tx in senders {
+            match tx.try_send(env.clone()) {
+                Ok(()) => {
+                    // Subscriber is alive and accepted the message.
+                    survivors.push(tx);
+                }
+                Err(_) => {
+                    // Channel is full or receiver was dropped; evict.
+                    // Best-effort delivery: slow or dead subscribers are removed.
+                }
+            }
+        }
+
+        // Only update the map if something changed.
+        // This avoids unnecessary write-lock contention on the subscriber map.
+        if survivors.len() != original_len {
+            let mut map = self.subscribers.write().await;
+            map.insert(topic.to_string(), survivors);
+        }
+    } // handle_incoming
 }
 
 #[async_trait::async_trait]
 impl Transport for MqttAsyncClientTransport {
     // ---
+
     fn transport_id(&self) -> &str {
         &self.transport_id
     }
 
     async fn publish(&self, env: Envelope, _opts: PublishOptions) -> Result<()> {
         // ---
-        // TODO: For MQTT implementation:
-        // - map Address -> MQTT topic
-        // - serialize Envelope metadata into MQTT properties
-        // - publish via MQTT client
-        //
-        // For now, simulate fanout using subscription manager.
-        // This allows testing the RPC layer even without MQTT.
-        self.subscriptions.fanout(&env, &self.transport_id).await;
+        let (tx, rx) = oneshot::channel();
 
-        Ok(())
+        self.cmd_tx
+            .send(Cmd::Publish { env, resp: tx })
+            .await
+            .map_err(|_| Error::Transport)?;
+
+        rx.await.map_err(|_| Error::Transport)?
     }
 
     async fn subscribe(
@@ -53,55 +368,81 @@ impl Transport for MqttAsyncClientTransport {
         _opts: SubscribeOptions,
     ) -> Result<SubscriptionHandle> {
         // ---
-        #[cfg(feature = "logging")]
-        log::debug!("{}: subscribe to {:?}", self.transport_id(), sub);
 
-        // TODO: For MQTT implementation:
-        // - map Subscription -> MQTT topic filter
-        // - subscribe via MQTT client
-        // - forward incoming MQTT messages to subscription manager
-        //
-        // For now, use subscription manager directly.
-        let rx = self.subscriptions.add(sub).await;
+        let topic = sub.0.as_ref().to_string();
+
+        let (tx, rx) = mpsc::channel(16);
+        {
+            let mut map = self.subscribers.write().await;
+            map.entry(topic.clone()).or_default().push(tx);
+        }
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+
+        self.cmd_tx
+            .send(Cmd::Subscribe {
+                topic,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| Error::Transport)?;
+
+        resp_rx.await.map_err(|_| Error::Transport)??;
 
         Ok(SubscriptionHandle { inbox: rx })
     }
 
     async fn close(&self) -> Result<()> {
         // ---
-        #[cfg(feature = "logging")]
-        log::debug!("{}: closing transport...", self.transport_id());
 
-        // TODO: For MQTT implementation:
-        // - gracefully disconnect MQTT client
-        // - wait for pending publishes/acks
-        //
-        // For now, just clear subscriptions.
-        self.subscriptions.clear().await;
+        let (tx, rx) = oneshot::channel();
+
+        let _ = self.cmd_tx.send(Cmd::Close { resp: tx }).await;
+        let _ = rx.await;
+
+        let mut tasks = self.tasks.write().await;
+        while let Some(handle) = tasks.pop() {
+            let _ = handle.await;
+        }
 
         Ok(())
     }
 }
 
-/// Create an MQTT-based transport using mqtt-async-client.
-///
-/// This is the ONLY symbol exposed from this module.
-pub async fn create_transport(transport_id: &str) -> Result<TransportPtr> {
+pub async fn create_transport(config: &RpcConfig) -> Result<TransportPtr> {
     // ---
-    // TODO:
-    // - build mqtt-async-client options from config
-    // - connect MQTT client
-    // - set up background receive loop for incoming messages
-    // - wire MQTT messages into subscription manager
-    //
-    #[cfg(feature = "logging")]
-    log::debug!("{}: create mqtt_async_client transport", transport_id);
+    let client = create_mqtt_client(config).await?;
+    Ok(MqttAsyncClientTransport::creat("mqtt-async-client", client))
+}
 
-    let transport = MqttAsyncClientTransport {
-        // ---
-        transport_id: transport_id.to_owned(),
-        subscriptions: SubscriptionManager::new(),
-    };
+async fn create_mqtt_client(config: &RpcConfig) -> Result<Client> {
+    // ---
+    let broker_addr = &config.broker_addr;
+    let client_id = &config.transport_id;
 
-    Ok(Arc::new(transport))
+    let mut builder = Client::builder();
+    builder.set_url_string(broker_addr).map_err(|_err| {
+        log_error!("mqtt: failed to set broker URL {}: {_err}", broker_addr);
+        Error::Transport
+    })?;
+
+    builder.set_client_id(Some(client_id.clone()));
+
+    if let Some(keep_alive_secs) = config.keep_alive_secs {
+        builder.set_keep_alive(KeepAlive::Enabled {
+            secs: keep_alive_secs,
+        });
+    }
+
+    let mut client = builder.build().map_err(|_err| {
+        log_error!("mqtt: failed to build client: {_err}");
+        Error::Transport
+    })?;
+
+    client.connect().await.map_err(|_err| {
+        log_error!("mqtt: failed to connect to broker {}: {_err}", broker_addr);
+        Error::Transport
+    })?;
+
+    Ok(client)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,12 +4,21 @@ use tokio::task::JoinHandle;
 
 use mom_rpc::{
     //
-    create_transport,
+    create_memory_transport,
+    Error,
     Result,
     RpcClient,
+    RpcConfig,
     RpcServer,
     TransportPtr,
 };
+
+macro_rules! log_info {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "logging")]
+        log::info!($($arg)*);
+    };
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct AddRequest {
@@ -27,34 +36,46 @@ struct MathServer {
     handle: JoinHandle<Result<()>>,
     _server: RpcServer,
     transport: TransportPtr,
+    node_id: String,
 }
 
 impl MathServer {
     // ---
     async fn new(id: &str) -> Result<Self> {
         // ---
-        let transport = create_transport(id).await?;
-        let server = RpcServer::new(transport.clone(), "math".to_owned());
+
+        let config = RpcConfig::memory(id);
+        let transport = create_memory_transport(&config).await?;
+        // Use test-specific node_id to avoid subscription conflicts
+        let node_id = format!("math-{}", id);
+        let server = RpcServer::new(transport.clone(), node_id.clone());
 
         server.register("add", |req: AddRequest| async move {
             // ---
             Ok(AddResponse { sum: req.a + req.b })
         });
-        let handle = server.run().await?;
+        let handle = server.spawn();
+
+        // Give the server task time to subscribe before returning
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
         Ok(Self {
             handle,
             _server: server,
             transport,
+            node_id,
         })
     }
 
     async fn shutdown(self) -> Result<()> {
         // --
-        // async cleanup
+        // Shutdown server first (signals run loop to exit)
+        self._server.shutdown().await?;
+
+        // Then close transport
         self.transport.close().await?;
 
-        // JoinError -> panic, inner Result -> ?
+        // Wait for server task to complete
         self.handle.await.expect("server task panicked")?;
 
         Ok(())
@@ -62,6 +83,10 @@ impl MathServer {
 
     fn transport(&self) -> TransportPtr {
         self.transport.clone()
+    }
+
+    fn node_id(&self) -> &str {
+        &self.node_id
     }
 }
 
@@ -71,23 +96,23 @@ async fn test_basic_request() -> Result<()> {
     #[cfg(feature = "logging")]
     init_logging();
 
-    log::info!("Starting basic request test");
+    log_info!("Starting basic request test");
 
     let server = MathServer::new("test_basic_request").await?;
-    log::info!("after MathServer::new");
+    log_info!("after MathServer::new");
 
     let client = RpcClient::with_transport(server.transport(), "Sally".to_string()).await?;
-    log::info!("after RpcClient::new");
+    log_info!("after RpcClient::new");
 
-    log::info!("sending math add 2 3...");
+    log_info!("sending math add 2 3...");
     let resp: AddResponse = client
-        .request_to("math", "add", AddRequest { a: 2, b: 3 })
+        .request_to(server.node_id(), "add", AddRequest { a: 2, b: 3 })
         .await?;
-    log::info!("sending math add 2 3...done");
+    log_info!("sending math add 2 3...done");
 
     assert_eq!(resp.sum, 5);
 
-    log::info!("calling server shutdown");
+    log_info!("calling server shutdown");
 
     server.shutdown().await?;
     Ok(())
@@ -104,15 +129,17 @@ async fn test_concurrent_requests() {
         .await
         .unwrap();
 
+    let node_id = server.node_id().to_string();
     let mut handles = Vec::new();
 
     for i in 0..10 {
         // ---
         let c = client.clone();
+        let node_id = node_id.clone();
 
         handles.push(tokio::spawn(async move {
             let resp: AddResponse = c
-                .request_to("math", "add", AddRequest { a: i, b: i })
+                .request_to(&node_id, "add", AddRequest { a: i, b: i })
                 .await
                 .unwrap();
             resp.sum
@@ -132,34 +159,173 @@ async fn test_timeout() -> Result<()> {
     #[cfg(feature = "logging")]
     init_logging();
 
-    let transport = create_transport("test_timeout").await?;
+    let config = RpcConfig::memory("test_timeout");
+    let transport = create_memory_transport(&config).await?;
     let server = RpcServer::new(transport.clone(), "lazy-math".to_owned());
-    let handle = server.run().await?;
 
     server.register("add", |req: AddRequest| async move {
-        std::thread::sleep(std::time::Duration::from_millis(1000));
+        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
         Ok(AddResponse { sum: req.a + req.b })
     });
 
+    let handle = server.spawn();
+
+    // Give the server task time to subscribe
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
     let client = RpcClient::with_transport(transport.clone(), "Denis".to_string()).await?;
 
-    log::info!("test_timeout: sending 1 + 1");
+    log_info!("test_timeout: sending 1 + 1");
 
     let fut =
-        client.request_to::<AddRequest, AddResponse>("math", "add", AddRequest { a: 1, b: 1 });
+        client.request_to::<AddRequest, AddResponse>("lazy-math", "add", AddRequest { a: 1, b: 1 });
 
     let res = tokio::time::timeout(Duration::from_millis(200), fut).await;
 
     assert!(res.is_err(), "request unexpectedly completed");
 
-    log::info!("test_timeout: {:?}", res);
+    log_info!("test_timeout: {:?}", res);
 
-    log::info!("test_timeout: closing transport");
+    log_info!("test_timeout: shutting down server");
+    server.shutdown().await?;
+
+    log_info!("test_timeout: closing transport");
     transport.close().await?;
 
-    log::info!("test_timeout: join handler");
+    log_info!("test_timeout: join handler");
     handle.await.expect("test_timeout:: server task panicked")?;
 
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore] // TODO: Implement error response protocol
+async fn test_error_response() -> Result<()> {
+    #[cfg(feature = "logging")]
+    init_logging();
+
+    let config = RpcConfig::memory("test_error");
+    let transport = create_memory_transport(&config).await?;
+    let server = RpcServer::new(transport.clone(), "error-math".to_owned());
+
+    server.register("divide", |req: AddRequest| async move {
+        if req.b == 0 {
+            return Err(Error::InvalidRequest);
+        }
+        Ok(AddResponse { sum: req.a / req.b })
+    });
+
+    let handle = server.spawn();
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let client = RpcClient::with_transport(transport.clone(), "error-client".to_string()).await?;
+
+    // Test error case
+    let result: Result<AddResponse> = client
+        .request_to("error-math", "divide", AddRequest { a: 10, b: 0 })
+        .await;
+    assert!(result.is_err(), "expected error for division by zero");
+
+    // Test success case
+    let resp: AddResponse = client
+        .request_to("error-math", "divide", AddRequest { a: 10, b: 2 })
+        .await?;
+    assert_eq!(resp.sum, 5);
+
+    server.shutdown().await?;
+    transport.close().await?;
+    handle.await.expect("server task panicked")?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_multiple_clients() -> Result<()> {
+    #[cfg(feature = "logging")]
+    init_logging();
+
+    let config = RpcConfig::memory("test_multi_client");
+    let transport = create_memory_transport(&config).await?;
+    let server = RpcServer::new(transport.clone(), "multi-math".to_owned());
+
+    server.register("add", |req: AddRequest| async move {
+        Ok(AddResponse { sum: req.a + req.b })
+    });
+
+    let handle = server.spawn();
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    // Create 3 separate clients
+    let client1 = RpcClient::with_transport(transport.clone(), "client-1".to_string()).await?;
+    let client2 = RpcClient::with_transport(transport.clone(), "client-2".to_string()).await?;
+    let client3 = RpcClient::with_transport(transport.clone(), "client-3".to_string()).await?;
+
+    // All clients make requests concurrently
+    let (r1, r2, r3) = tokio::join!(
+        client1.request_to::<AddRequest, AddResponse>(
+            "multi-math",
+            "add",
+            AddRequest { a: 1, b: 1 }
+        ),
+        client2.request_to::<AddRequest, AddResponse>(
+            "multi-math",
+            "add",
+            AddRequest { a: 2, b: 2 }
+        ),
+        client3.request_to::<AddRequest, AddResponse>(
+            "multi-math",
+            "add",
+            AddRequest { a: 3, b: 3 }
+        ),
+    );
+
+    assert_eq!(r1?.sum, 2);
+    assert_eq!(r2?.sum, 4);
+    assert_eq!(r3?.sum, 6);
+
+    server.shutdown().await?;
+    transport.close().await?;
+    handle.await.expect("server task panicked")?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore] // TODO: Implement error response protocol
+async fn test_transport_disconnect() -> Result<()> {
+    #[cfg(feature = "logging")]
+    init_logging();
+
+    let config = RpcConfig::memory("test_disconnect");
+    let transport = create_memory_transport(&config).await?;
+    let server = RpcServer::new(transport.clone(), "disconnect-math".to_owned());
+
+    server.register("add", |req: AddRequest| async move {
+        // Slow handler to ensure request is in-flight
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        Ok(AddResponse { sum: req.a + req.b })
+    });
+
+    let handle = server.spawn();
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let client =
+        RpcClient::with_transport(transport.clone(), "disconnect-client".to_string()).await?;
+
+    // Start request
+    let fut = client.request_to::<AddRequest, AddResponse>(
+        "disconnect-math",
+        "add",
+        AddRequest { a: 1, b: 1 },
+    );
+
+    // Close transport while request is in-flight
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    transport.close().await?;
+
+    // Request should fail
+    let result = fut.await;
+    assert!(result.is_err(), "expected error after transport disconnect");
+
+    handle.await.expect("server task panicked")?;
     Ok(())
 }
 

--- a/tests/transport_memory.rs
+++ b/tests/transport_memory.rs
@@ -9,6 +9,7 @@ use mom_rpc::{
     CorrelationId,
     Envelope,
     PublishOptions,
+    RpcConfig,
     SubscribeOptions,
 };
 
@@ -17,7 +18,9 @@ async fn memory_subscribe_then_publish_delivers() {
     // ---
     // Arrange
     // ---
-    let transport = mom_rpc::create_memory_transport("mstpd")
+    let config = RpcConfig::memory("mstpd");
+
+    let transport = mom_rpc::create_memory_transport(&config)
         .await
         .expect("failed to create memory transport");
 


### PR DESCRIPTION
- Actor-based MQTT transport with topic fanout
- Implement topic-based fanout to match memory transport semantics
- Unify transport construction via RpcConfig
- Improved RpcServer run/shutdown semantics
- Update examples and integration
- Add CI code-quality checks
