### PR TITLE
Remove unused SubscribeOptions from Transport API (#5)

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -19,7 +19,6 @@ use crate::{
     PublishOptions,
     Result,
     RpcError,
-    SubscribeOptions,
     Subscription,
     TransportPtr,
 };
@@ -88,9 +87,7 @@ impl RpcClient {
         // but they should approximate memory semantics where possible.
         let response_sub: Subscription = Subscription::from(format!("responses/{node_id}"));
 
-        let mut handle = transport
-            .subscribe(response_sub, SubscribeOptions { durable: false })
-            .await?;
+        let mut handle = transport.subscribe(response_sub).await?;
 
         // We need a partially built client to call handle_response().
         let pending: Mutex<PendingMap> = Mutex::new(PendingMap::new());

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -16,7 +16,6 @@ pub use transport::{
     Address,
     Envelope,
     PublishOptions,
-    SubscribeOptions,
     Subscription,
     SubscriptionHandle,
     Transport,

--- a/src/domain/transport.rs
+++ b/src/domain/transport.rs
@@ -177,30 +177,9 @@ pub struct PublishOptions {
     pub ttl_ms: Option<u64>,
 }
 
-/// Options controlling subscription behavior.
-///
-/// These options express intent only. Not all transports are required to
-/// support all options.
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub struct SubscribeOptions {
-    // ---
-    /// Whether this subscription should persist across disconnections.
-    ///
-    /// When `true`, the broker maintains the subscription and queues messages
-    /// even when the transport disconnects. When `false`, subscriptions are
-    /// dropped on disconnect.
-    ///
-    /// **Note:** Durable subscriptions currently have no explicit cleanup
-    /// mechanism. See issue #5 for adding `unsubscribe()` support.
-    pub durable: bool,
-}
-
 /// Handle returned from a successful subscription.
 ///
-/// Dropping the handle indicates that the subscription is no longer needed.
-/// Transport implementations may use this as a signal to unregister the
-/// subscription.
+/// The subscription remains active until the transport is closed.
 pub struct SubscriptionHandle {
     // ---
     /// Receiver channel for delivered envelopes matching this subscription.
@@ -246,11 +225,7 @@ pub trait Transport: Send + Sync {
     async fn publish(&self, env: Envelope, opts: PublishOptions) -> Result<()>;
 
     /// Register a subscription and return a handle for receiving messages.
-    async fn subscribe(
-        &self,
-        sub: Subscription,
-        opts: SubscribeOptions,
-    ) -> Result<SubscriptionHandle>;
+    async fn subscribe(&self, sub: Subscription) -> Result<SubscriptionHandle>;
 
     /// Close the transport and release any associated resources.
     async fn close(&self) -> Result<()>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,6 @@ pub use domain::{
     Address,
     Envelope,
     PublishOptions,
-    SubscribeOptions,
     Subscription,
     SubscriptionHandle,
     Transport,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,8 +8,6 @@ use bytes::Bytes;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
-use crate::SubscribeOptions;
-
 use super::{
     // ---
     Address,
@@ -204,11 +202,7 @@ impl RpcServer {
         // ---
         let sub = Subscription::from(format!("requests/{}", self.node_id()));
 
-        let mut handle = self
-            .inner
-            .transport
-            .subscribe(sub, SubscribeOptions { durable: false })
-            .await?;
+        let mut handle = self.inner.transport.subscribe(sub).await?;
 
         loop {
             tokio::select! {

--- a/src/transport/memory/transport.rs
+++ b/src/transport/memory/transport.rs
@@ -23,7 +23,6 @@ use crate::{
     PublishOptions,
     Result,
     RpcConfig,
-    SubscribeOptions,
     Subscription,
     SubscriptionHandle,
     Transport,
@@ -41,7 +40,7 @@ use crate::{
 /// - Subscriptions are registered immediately.
 /// - Once `subscribe()` returns, subsequent matching publishes are deliverable.
 /// - Message delivery is deterministic within a single process.
-/// - Dropping a `SubscriptionHandle` implicitly unregisters the subscription.
+/// - Subscriptions remain active until the transport is closed.
 ///
 /// ## Non-Goals
 ///
@@ -99,11 +98,7 @@ impl Transport for MemoryTransport {
     /// Once this function returns successfully, any subsequent calls to
     /// `publish()` with matching addresses are deliverable to the returned
     /// inbox.
-    async fn subscribe(
-        &self,
-        sub: Subscription,
-        _opts: SubscribeOptions,
-    ) -> Result<SubscriptionHandle> {
+    async fn subscribe(&self, sub: Subscription) -> Result<SubscriptionHandle> {
         // ---
 
         #[cfg(feature = "logging")]

--- a/src/transport/rumqttc/transport.rs
+++ b/src/transport/rumqttc/transport.rs
@@ -82,7 +82,6 @@ use crate::{
     Result,
     RpcConfig,
     RpcError,
-    SubscribeOptions,
     Subscription,
     SubscriptionHandle,
     Transport,
@@ -562,11 +561,7 @@ impl Transport for RumqttcTransport {
         })?
     }
 
-    async fn subscribe(
-        &self,
-        sub: Subscription,
-        _opts: SubscribeOptions,
-    ) -> Result<SubscriptionHandle> {
+    async fn subscribe(&self, sub: Subscription) -> Result<SubscriptionHandle> {
         // ---
 
         let topic = sub.0.as_ref().to_string();

--- a/tests/transport_memory.rs
+++ b/tests/transport_memory.rs
@@ -10,7 +10,6 @@ use mom_rpc::{
     Envelope,
     PublishOptions,
     RpcConfig,
-    SubscribeOptions,
 };
 
 #[tokio::test]
@@ -27,7 +26,7 @@ async fn memory_subscribe_then_publish_delivers() {
     let address = Address::from("test.address");
 
     let mut sub = transport
-        .subscribe(address.clone().into(), SubscribeOptions { durable: false })
+        .subscribe(address.clone().into())
         .await
         .expect("subscribe failed");
 


### PR DESCRIPTION
- Remove `SubscribeOptions` struct (unused durable field)
- Simplify `Transport::subscribe()` signature
- Update all implementations and callers
- Document that subscriptions remain active until close()

Closes #5 - unsubscribe() not needed for long-lived RPC usage; brokers auto-cleanup subscriptions on disconnect.