### PR TITLE
fix: add missing blank line in server broker code fench example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows a design-first, architecture-driven development model.
 Early versions may include intentional refactors as semantics are clarified.
 
 ---
+## [0.5.2] - 2026-02-09
+
+### Fixed
+
+- Add missing blank line in server broker code fence example
+  - Markdown requires blank line between HTML tags and code fences
 
 ## [0.5.1] - 2026-02-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "mom-rpc"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mom-rpc"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["John Basrai"]
 description = "Transport-agnostic async RPC over message-oriented middleware (AMQP, MQTT, in-memory)"

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ let resp: AddResponse = client.request_to("math", "add", AddRequest { a: 2, b: 3
 
 <details>
 <summary><b>View complete server with broker example</b></summary>
+
 ```rust
 
 use mom_rpc::{create_transport, RpcConfig, RpcServer};


### PR DESCRIPTION
Markdown requires blank line between HTML tags and code fences.