### PR TITLE
feat: Release 0.6.0: Breaking changes batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ This project follows a design-first, architecture-driven development model.
 Early versions may include intentional refactors as semantics are clarified.
 
 ---
+
+## [0.6.0] - 2026-02-09
+
+### Added
+
+- **MQTT manual integration test** - `scripts/manual-tests/mqtt.sh` for testing `transport_rumqttc` against real Mosquitto broker
+- **Timeout convenience method** - `RpcClient::request_with_timeout()` for simpler timeout handling
+
+### Changed (BREAKING)
+
+- **Removed `PublishOptions`** - Simplified `Transport::publish()` to remove unused options parameter
+  - RPC semantics always use non-durable delivery with no TTL
+  - **Breaking:** Custom `Transport` implementations must update `publish()` signature
+  - **Non-breaking:** Public API users (`RpcClient`, `RpcServer`) are unaffected
+
+### Documentation
+
+- Updated timeout handling section in README to feature `request_with_timeout` method
+- Added comprehensive tests for timeout functionality
+
+---
+
 ## [0.5.3] - Unreleased
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "mom-rpc"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mom-rpc"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 authors = ["John Basrai"]
 description = "Transport-agnostic async RPC over message-oriented middleware (AMQP, MQTT, in-memory)"
@@ -22,7 +22,7 @@ rumqttc      = { version = "0.24", optional = true }
 serde        = { version = "1", features = ["derive", "rc"] }
 serde_json   = "1"
 thiserror    = "2"
-tokio        = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+tokio        = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-util   = { version = "0.7", features = ["compat"], optional = true }
 uuid         = { version  = "1.11", features = ["v4", "serde"] }
 

--- a/README.md
+++ b/README.md
@@ -382,27 +382,23 @@ mom-rpc = "0.4"  # Memory transport included by default
 
 ## Timeout Handling
 
-The RPC layer does not impose timeouts. Use `tokio::time::timeout` to add them:
-
-<details>
-<summary><b>Show timeout example</b></summary>
+Use the built-in `request_with_timeout` method for convenient timeout handling:
 
 ```rust
-use tokio::time::{timeout, Duration};
+use std::time::Duration;
 
-let result = timeout(
-    Duration::from_secs(5),
-    client.request_to("service", "method", request)
-).await;
+// Recommended: built-in timeout method
+let response: MyResponse = client
+    .request_with_timeout(
+        "service",
+        "method",
+        request,
+        Duration::from_secs(5),
+    )
+    .await?;
 
-match result {
-    Ok(Ok(response)) => { /* success */ }
-    Ok(Err(e)) => { /* RPC error */ }
-    Err(_) => { /* timeout */ }
-}
+// Returns RpcError::Timeout if request exceeds timeout
 ```
-
-</details>
 
 ---
 

--- a/scripts/manual-tests/README.md
+++ b/scripts/manual-tests/README.md
@@ -31,7 +31,7 @@ Tests AMQP transport implementations against a RabbitMQ broker.
 1. Starts RabbitMQ in Docker
 2. Builds math_server and math_client examples with specified feature
 3. Runs server in background
-4. Runs client and validates output contains "Result: 42"
+4. Runs client and validates output contains "2 + 3 = 5"
 5. Cleans up (kills server, stops container)
 
 **Management UI:**
@@ -39,13 +39,25 @@ Tests AMQP transport implementations against a RabbitMQ broker.
 - Username: `guest`
 - Password: `guest`
 
-### MQTT (planned)
+### MQTT
 
+Tests MQTT transport implementations against a Mosquitto broker.
+
+**Usage:**
 ```bash
 ./mqtt.sh transport_rumqttc
 ```
 
-Tests MQTT transport implementations against a Mosquitto broker.
+**Requirements:**
+- Docker installed and running
+- Port 1883 (MQTT) available
+
+**What it does:**
+1. Starts Mosquitto in Docker
+2. Builds math_server and math_client examples with specified feature
+3. Runs server in background
+4. Runs client and validates output contains "2 + 3 = 5"
+5. Cleans up (kills server, stops container)
 
 ## Design Principles
 
@@ -91,7 +103,7 @@ pkill -f math_server
 
 # Remove containers
 docker rm -f mom-rpc-test-rabbitmq
-docker rm -f mom-rpc-test-mqtt
+docker rm -f mom-rpc-test-mosquitto
 ```
 
 ## Adding New Tests

--- a/scripts/manual-tests/mqtt.sh
+++ b/scripts/manual-tests/mqtt.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# MQTT Manual Integration Test
+#
+# Tests MQTT transport implementations against a real Mosquitto broker.
+# Multiple MQTT libraries can use the same script by passing different feature flags.
+#
+# Usage: ./mqtt.sh <feature-flag>
+# Example: ./mqtt.sh transport_rumqttc
+
+FEATURE="${1:-}"
+CONTAINER_NAME="mom-rpc-test-mosquitto"
+MQTT_PORT=1883
+BROKER_URI="mqtt://localhost:${MQTT_PORT}"
+
+# ---
+
+usage() {
+    echo "Usage: $0 <feature-flag>"
+    echo ""
+    echo "Example:"
+    echo "  $0 transport_rumqttc"
+    echo ""
+    echo "This script:"
+    echo "  1. Starts a Mosquitto MQTT broker in Docker"
+    echo "  2. Builds and runs math_server example"
+    echo "  3. Runs math_client example and validates output"
+    echo "  4. Cleans up (kills server, stops container)"
+    exit 1
+}
+
+if [ -z "$FEATURE" ]; then
+    echo "Error: Feature flag required"
+    usage
+fi
+
+# ---
+
+echo "==> Checking prerequisites..."
+
+if ! command -v docker &> /dev/null; then
+    echo "Error: Docker is required but not found"
+    echo "Install Docker: https://docs.docker.com/get-docker/"
+    exit 1
+fi
+
+if ! command -v cargo &> /dev/null; then
+    echo "Error: cargo is required but not found"
+    exit 1
+fi
+
+# ---
+
+cleanup() {
+    echo ""
+    echo "==> Cleaning up..."
+    
+    # Kill server process
+    if [ -n "${SERVER_PID:-}" ]; then
+        echo "Killing server (PID: $SERVER_PID)..."
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    
+    # Stop and remove container
+    if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+        echo "Stopping Mosquitto container..."
+        docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        docker rm "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+    
+    # Remove temp files
+    rm -f server.log client.log *.build.log
+}
+
+trap cleanup EXIT INT TERM
+
+# ---
+
+echo "==> Starting Mosquitto MQTT broker..."
+echo "    Container: $CONTAINER_NAME"
+echo "    MQTT port: $MQTT_PORT"
+
+# Remove existing container if present
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+# Start Mosquitto with anonymous access enabled for testing
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "${MQTT_PORT}:1883" \
+    eclipse-mosquitto:latest \
+    mosquitto -c /mosquitto-no-auth.conf \
+    >/dev/null
+
+echo "    Waiting for broker to be ready..."
+sleep 2
+
+# Verify broker is accessible by checking if container is running
+if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "Error: Mosquitto broker failed to start properly"
+    docker logs "$CONTAINER_NAME"
+    exit 1
+fi
+
+echo "    ✓ Mosquitto broker ready"
+
+# ---
+
+echo ""
+echo "==> Building examples with feature: $FEATURE"
+
+if ! cargo build --example math_server --features "$FEATURE" >& math_server.build.log; then
+    echo "Error: Failed to build math_server"
+    cat math_server.build.log
+    exit 1
+fi
+
+if ! cargo build --example math_client --features "$FEATURE" >& math_client.build.log; then
+    echo "Error: Failed to build math_client"
+    cat math_client.build.log
+    exit 1
+fi
+
+echo "    ✓ Examples built successfully"
+
+# ---
+
+echo ""
+echo "==> Starting math_server..."
+
+# Set broker URI via environment variable (examples should read this)
+export BROKER_URI="$BROKER_URI"
+
+cargo run --quiet --example math_server --features "$FEATURE" > server.log 2>&1 &
+SERVER_PID=$!
+
+echo "    Server PID: $SERVER_PID"
+echo "    Waiting for server to initialize..."
+sleep 3
+
+# Check if server is still running
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Error: Server process died"
+    echo "Server logs:"
+    cat server.log
+    exit 1
+fi
+
+echo "    ✓ Server running"
+
+# ---
+
+echo ""
+echo "==> Running math_client..."
+
+if cargo run --quiet --example math_client --features "$FEATURE" 2>&1 | tee client.log | grep -q "2 + 3 = 5"; then
+    echo ""
+    echo "✅ MQTT integration test PASSED"
+    echo ""
+    echo "Feature tested: $FEATURE"
+    echo "Broker URI: $BROKER_URI"
+    echo -n "Output:"
+    cat  client.log
+    exit 0
+else
+    echo ""
+    echo "❌ MQTT integration test FAILED"
+    echo ""
+    echo "Expected output containing '2 + 3 = 5' but didn't find it"
+    echo ""
+    echo "Client output:"
+    cat client.log
+    echo ""
+    echo "Server logs:"
+    cat server.log
+    exit 1
+fi

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -15,7 +15,6 @@ pub use transport::{
     //
     Address,
     Envelope,
-    PublishOptions,
     Subscription,
     SubscriptionHandle,
     Transport,

--- a/src/domain/transport.rs
+++ b/src/domain/transport.rs
@@ -161,22 +161,6 @@ impl Envelope {
     }
 }
 
-/// Options controlling message publication.
-///
-/// These options express delivery intent at the domain level. Concrete
-/// transports may ignore, approximate, or map these options onto their
-/// own mechanisms.
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub struct PublishOptions {
-    // ---
-    /// Whether the message should be treated as durable.
-    pub durable: bool,
-
-    /// Optional time-to-live for the message, in milliseconds.
-    pub ttl_ms: Option<u64>,
-}
-
 /// Handle returned from a successful subscription.
 ///
 /// The subscription remains active until the transport is closed.
@@ -222,7 +206,10 @@ pub trait Transport: Send + Sync {
     fn transport_id(&self) -> &str;
 
     /// Publish an envelope to the given address.
-    async fn publish(&self, env: Envelope, opts: PublishOptions) -> Result<()>;
+    ///
+    /// RPC semantics always use non-durable delivery with no TTL.
+    /// Transports implement their own default QoS settings for RPC patterns.
+    async fn publish(&self, env: Envelope) -> Result<()>;
 
     /// Register a subscription and return a handle for receiving messages.
     async fn subscribe(&self, sub: Subscription) -> Result<SubscriptionHandle>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,6 @@ pub use domain::{
     //
     Address,
     Envelope,
-    PublishOptions,
     Subscription,
     SubscriptionHandle,
     Transport,

--- a/src/server/rpc_server.rs
+++ b/src/server/rpc_server.rs
@@ -29,7 +29,6 @@ use crate::{
     // ---
     Address,
     Envelope,
-    PublishOptions,
     Result,
     RpcError,
     Subscription,
@@ -299,16 +298,7 @@ impl RpcServer {
             Arc::<str>::from("application/json"),
         );
 
-        self.inner
-            .transport
-            .publish(
-                env,
-                PublishOptions {
-                    durable: false,
-                    ttl_ms: None,
-                },
-            )
-            .await
+        self.inner.transport.publish(env).await
     }
 
     #[cfg(false)]

--- a/src/transport/amqp/lapin.rs
+++ b/src/transport/amqp/lapin.rs
@@ -83,7 +83,6 @@ use tokio::task::JoinHandle;
 use crate::{
     //
     Envelope,
-    PublishOptions,
     Result,
     RpcConfig,
     RpcError,
@@ -390,7 +389,7 @@ impl Transport for AmqpTransport {
         &self.transport_id
     }
 
-    async fn publish(&self, env: Envelope, _opts: PublishOptions) -> Result<()> {
+    async fn publish(&self, env: Envelope) -> Result<()> {
         // ---
         let (tx, rx) = oneshot::channel();
 

--- a/src/transport/memory.rs
+++ b/src/transport/memory.rs
@@ -34,7 +34,6 @@ use crate::{
     // ---
     Address,
     Envelope,
-    PublishOptions,
     Result,
     RpcConfig,
     Subscription,
@@ -81,7 +80,7 @@ impl Transport for MemoryTransport {
     ///
     /// This behavior defines the reference matching semantics for the
     /// transport layer.
-    async fn publish(&self, env: Envelope, _opts: PublishOptions) -> Result<()> {
+    async fn publish(&self, env: Envelope) -> Result<()> {
         // ---
         let subs = self.subscriptions.read().await;
 

--- a/src/transport/mqtt/rumqttc.rs
+++ b/src/transport/mqtt/rumqttc.rs
@@ -78,7 +78,6 @@ use tokio::task::JoinHandle;
 use crate::{
     //
     Envelope,
-    PublishOptions,
     Result,
     RpcConfig,
     RpcError,
@@ -542,7 +541,7 @@ impl Transport for RumqttcTransport {
         &self.transport_id
     }
 
-    async fn publish(&self, env: Envelope, _opts: PublishOptions) -> Result<()> {
+    async fn publish(&self, env: Envelope) -> Result<()> {
         // ---
 
         let (tx, rx) = oneshot::channel();

--- a/tests/transport_memory.rs
+++ b/tests/transport_memory.rs
@@ -8,7 +8,6 @@ use mom_rpc::{
     Address,
     CorrelationId,
     Envelope,
-    PublishOptions,
     RpcConfig,
 };
 
@@ -44,16 +43,7 @@ async fn memory_subscribe_then_publish_delivers() {
     // ---
     // Act
     // ---
-    transport
-        .publish(
-            env,
-            PublishOptions {
-                durable: false,
-                ttl_ms: None,
-            },
-        )
-        .await
-        .expect("publish failed");
+    transport.publish(env).await.expect("publish failed");
 
     // ---
     // Assert


### PR DESCRIPTION
BREAKING CHANGE: Remove PublishOptions from Transport::publish()
- Simplifies Transport trait - RPC always uses non-durable delivery
- Custom Transport implementations must update publish() signature
- Public API (RpcClient/RpcServer) users unaffected

Features:
- Add RpcClient::request_with_timeout() convenience method
- Add MQTT manual integration test (scripts/manual-tests/mqtt.sh)

Documentation:
- Update README timeout handling section
- Update CHANGELOG with 0.6.0 and corrected 0.5.3 entries

Closes #18, #20, #28