### PR TITLE
docs: update and cleanup for 0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 This project follows a design-first, architecture-driven development model.
 Early versions may include intentional refactors as semantics are clarified.
 
+## [0.6.2] - 2026-02-10
+
+### Fixed
+
+- Quick Start example in `lib.rs` was stale math example — replaced with sensor example
+- `request_with_timeout` doc example missing `TemperatureUnit` enum definition
+- Feature flag name `transport_amqp` → `transport_lapin` in `lib.rs` doc comment
+
+### Changed
+
+- Renamed `scripts/manual-tests/rabbitmq.sh` → `amqp.sh` (protocol-first naming convention)
+- Updated ARCHITECTURE.md: transport derivation lineage, pinned EMBP link, removed misleading multi-transport priority note
+- Feature flags table: clearer "Default Enable" column with ✅/❌ indicators
+- RabbitMQ expected test output updated to match actual sensor output
+- Security section now mentions both `rumqttc` and `lapin` transports
+- Version references in README updated from `0.4` to `0.x`
+
 ## [0.6.1] - 2026-02-10
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "mom-rpc"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mom-rpc"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["John Basrai"]
 description = "Transport-agnostic async RPC over message-oriented middleware (AMQP, MQTT, in-memory)"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ Transports are organized by **protocol → library** hierarchy:
 ```
 transport/
 ├── mod.rs
-├── memory.rs              # Flat - always available, brokerless
+├── memory.rs             # Flat - always available, brokerless
 ├── mqtt/
 │   ├── mod.rs            # Protocol gateway (EMBP)
 │   └── rumqttc.rs        # MQTT via rumqttc library
@@ -152,9 +152,7 @@ It:
 
 ### Reference Semantics
 
-All other transports are expected to **approximate the memory transport's behavior as closely as their underlying system allows**.
-
-In particular:
+Each brokered transport was derived from its predecessor, which structurally reinforces behavioral consistency rather than merely aspiring to it. That consistency targets the following reference semantics:
 
 * No message replay on subscribe
 * Fanout delivers messages to all subscribers

--- a/docs/contributing/CODE_STYLE.md
+++ b/docs/contributing/CODE_STYLE.md
@@ -42,7 +42,7 @@ struct MemoryTransport {
 impl Transport for MemoryTransport {
     // ---
     fn transport_id(&self) -> &str {
-        self.transport_id.as_str()
+        self.transport_id.as_str()    // Trivial function not required
     }
 
     async fn publish(&self, env: Envelope) -> Result<()> {
@@ -88,7 +88,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_delivery() {
         // ---
-        // test body
+        ... test body
     }
 }
 ```
@@ -96,7 +96,8 @@ mod tests {
 ## Style Guidelines
 
 1. Use `// ---` for visual separation after opening braces
-2. Place separator before the first meaningful line
+2. Place separator right after the line with open brace
+   - Adding extra blank line after // --- is Ok too.
 3. Use between meaningful logical steps within function bodies
 4. **Do NOT** use separators between fields in struct literals
 5. Keep separators consistent across the codebase

--- a/docs/contributing/DOCUMENTATION.md
+++ b/docs/contributing/DOCUMENTATION.md
@@ -45,10 +45,6 @@ For RPC and messaging code, doc comments should explicitly describe:
 /// - Request serialization fails
 /// - Publish fails
 ///
-/// # Timeouts
-///
-/// Timeouts are handled at the application layer. Consider using
-/// `tokio::time::timeout()` when awaiting the returned future.
 pub async fn request<Req, Resp>(&self, service: &str, method: &str, payload: &Req) 
     -> Result<Resp>
 where

--- a/docs/contributing/QUICK_START.md
+++ b/docs/contributing/QUICK_START.md
@@ -39,6 +39,8 @@ cargo test --lib
 cargo test
 ```
 
+Also browse the testing scripts in `scripts/` dirctory.
+
 ## Testing Feature Combinations
 
 This crate supports optional features:
@@ -57,8 +59,6 @@ cargo build --all-features
 ## Cross-Compilation
 
 This library is cross-platform and suitable for embedded/edge deployments. Cross-compilation and platform-specific concerns are handled at the consuming crate level.
-
-Once this crate stabilizes, [rust-edge-agent](https://github.com/JohnBasrai/rust-edge-agent) will be refactored to use mom-rpc as a reference example.
 
 ## Next Steps
 

--- a/scripts/ci-docs.sh
+++ b/scripts/ci-docs.sh
@@ -9,7 +9,8 @@ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --quiet
 
 # Check for missing docs on public items
 echo "    Checking for missing documentation..."
-cargo doc --all-features --no-deps 2>&1 | grep "warning.*missing documentation" && {
+RUSTDOCFLAGS="-D warnings" \
+    cargo doc --all-features --no-deps 2>&1 | grep "warning.*missing documentation" && {
   echo "❌ Found undocumented public items"
   exit 1
 } || true
@@ -21,3 +22,5 @@ cargo build --example sensor_server --features transport_rumqttc --quiet
 cargo build --example sensor_client --features transport_rumqttc --quiet
 
 echo "✅ Documentation OK"
+echo "You may view the docs with command:"
+echo "cargo doc --no-deps --all-features --open"

--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -36,7 +36,7 @@ echo ""
 # 2. Feature matrix testing
 echo "==> Feature Matrix"
 run_test "default features" "default"
-run_test "transport_rumqttc" "transport_rumqttc"
+run_test "rumqttc" "transport_rumqttc"
 run_test "no default features" "no-default-features"
 run_test "all features" "all-features"
 

--- a/scripts/manual-tests/README.md
+++ b/scripts/manual-tests/README.md
@@ -14,13 +14,13 @@ CI continues to use the fast, reliable memory transport for automated testing.
 
 ## Available Tests
 
-### RabbitMQ (AMQP)
+### AMQP
 
 Tests AMQP transport implementations against a RabbitMQ broker.
 
 **Usage:**
 ```bash
-./rabbitmq.sh transport_lapin
+./amqp.sh transport_lapin
 ```
 
 **Requirements:**
@@ -61,25 +61,25 @@ Tests MQTT transport implementations against a Mosquitto broker.
 
 ## Design Principles
 
-### Organized by Broker, Not Library
+### Organized by Protocol, Not Library
 
-Scripts are organized by **broker type** because:
+Scripts are organized by **protocol type** because:
 - Multiple libraries may implement the same protocol
 - Test logic is the same regardless of which library is used
 - Reduces duplication
 
 For example:
-- `rabbitmq.sh` can test `transport_lapin` or any future AMQP library
+- `amqp.sh` can test `transport_lapin` or any future AMQP library
 - `mqtt.sh` can test `transport_rumqttc`, `transport_paho`, etc.
 
 ### Feature Flag as Parameter
 
 Each script takes a feature flag as a parameter:
 ```bash
-./rabbitmq.sh transport_lapin          # Test lapin
-./rabbitmq.sh transport_another_amqp   # Future: test another AMQP lib
-./mqtt.sh transport_rumqttc            # Test rumqttc
-./mqtt.sh transport_paho               # Future: test paho
+./amqp.sh transport_lapin          # Test lapin
+./amqp.sh transport_another_amqp   # Future: test another AMQP lib
+./mqtt.sh transport_rumqttc        # Test rumqttc
+./mqtt.sh transport_paho           # Future: test paho
 ```
 
 This allows testing multiple implementations without duplicating test logic.
@@ -108,9 +108,9 @@ docker rm -f mom-rpc-test-mosquitto
 
 ## Adding New Tests
 
-To add a test for a new broker type:
+To add a test for a new protocol type:
 
-1. Create `scripts/manual-tests/broker_name.sh`
+1. Create `scripts/manual-tests/<protocol-name>.sh`
 2. Follow the pattern from existing scripts:
    - Accept feature flag as `$1`
    - Check prerequisites (Docker, cargo)
@@ -118,7 +118,7 @@ To add a test for a new broker type:
    - Build and run examples
    - Validate output
    - Clean up via trap
-3. Make executable: `chmod +x broker_name.sh`
+3. Make executable: `chmod +x <protocol-name>.sh`
 4. Update this README
 
 ## Notes

--- a/scripts/manual-tests/amqp.sh
+++ b/scripts/manual-tests/amqp.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# RabbitMQ Manual Integration Test
+# AMQP Manual Integration Test
 #
 # Tests AMQP transport implementations against a real RabbitMQ broker.
 # Multiple AMQP libraries can use the same script by passing different feature flags.
 #
-# Usage: ./rabbitmq.sh <feature-flag>
-# Example: ./rabbitmq.sh transport_lapin
+# Usage: ./amqp.sh <feature-flag>
+# Example: ./amqp.sh transport_lapin
 
 FEATURE="${1:-}"
 CONTAINER_NAME="mom-rpc-test-rabbitmq"
@@ -156,13 +156,13 @@ echo "    ✓ Server running"
 echo ""
 echo "==> Running sensor_client..."
 
-cargo --quiet run --example sensor_client --features "$FEATURE" 2>&1 |& tee client.log
+cargo --quiet run --example sensor_client --features "$FEATURE" >& client.log
 
 if grep -q  "Temperature" client.log && \
    grep -q  "Humidity"    client.log && \
    grep -q  "Pressure"    client.log  ; then
     echo ""
-    echo "✅ RabbitMQ integration test PASSED"
+    echo "✅ AMQP integration test PASSED"
     echo ""
     echo "Feature tested: $FEATURE"
     echo "Broker URI: $BROKER_URI"
@@ -171,7 +171,7 @@ if grep -q  "Temperature" client.log && \
     exit 0
 else
     echo ""
-    echo "❌ RabbitMQ integration test FAILED"
+    echo "❌ AMQP integration test FAILED"
     echo ""
     echo "Expected output not found"
     echo ""

--- a/scripts/manual-tests/mqtt.sh
+++ b/scripts/manual-tests/mqtt.sh
@@ -155,7 +155,7 @@ echo ""
 echo "==> Running sensor_client..."
 
 
-cargo --quiet run --example sensor_client --features "$FEATURE" 2>&1 |& tee client.log
+cargo --quiet run --example sensor_client --features "$FEATURE" >& client.log
 
 if grep -q  "Temperature" client.log && \
    grep -q  "Humidity"    client.log && \

--- a/src/client/pending.rs
+++ b/src/client/pending.rs
@@ -1,4 +1,4 @@
-use crate::protocol::CorrelationId;
+use super::CorrelationId;
 use bytes::Bytes;
 use std::collections::HashMap;
 use tokio::sync::oneshot;

--- a/src/client/rpc_client.rs
+++ b/src/client/rpc_client.rs
@@ -173,7 +173,7 @@ impl RpcClient {
 
     /// Send an RPC request to a target service node.
     ///
-    /// - `target_node_id`: service identity (e.g., `"math-service"`)
+    /// - `target_node_id`: service identity (e.g., `"sensor-service"`)
     /// - `method`: RPC method name
     /// - `req`: request payload
     pub async fn request_to<TReq, TResp>(
@@ -230,7 +230,7 @@ impl RpcClient {
     ///
     /// # Arguments
     ///
-    /// - `target_node_id`: service identity (e.g., `"math-service"`)
+    /// - `target_node_id`: service identity (e.g., `"sensor-service"`)
     /// - `method`: RPC method name
     /// - `req`: request payload
     /// - `timeout`: maximum time to wait for response
@@ -241,18 +241,26 @@ impl RpcClient {
     /// # use mom_rpc::{RpcClient, create_transport, RpcConfig};
     /// # use serde::{Deserialize, Serialize};
     /// # use std::time::Duration;
-    /// # #[derive(Serialize)] struct AddRequest { a: i32, b: i32 }
-    /// # #[derive(Deserialize)] struct AddResponse { sum: i32 }
+    /// #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+    /// pub enum TemperatureUnit { Celsius, Fahrenheit }
+    /// #[derive(Debug, Clone, Serialize, Deserialize)]
+    /// pub struct ReadTemperature { pub unit: TemperatureUnit }
+    /// #[derive(Debug, Clone, Serialize, Deserialize)]
+    /// pub struct SensorReading {
+    ///     pub value: f32,
+    ///     pub unit: String,
+    ///     pub timestamp_ms: u64,
+    /// }
     /// # async fn example() -> mom_rpc::Result<()> {
     /// let config = RpcConfig::memory("client");
     /// let transport = create_transport(&config).await?;
     /// let client = RpcClient::with_transport(transport, "client").await?;
     ///
-    /// let resp: AddResponse = client
+    /// let resp: SensorReading = client
     ///     .request_with_timeout(
-    ///         "math",
-    ///         "add",
-    ///         AddRequest { a: 2, b: 3 },
+    ///         "env-sensor-42",
+    ///         "read_temperature",
+    ///         ReadTemperature { unit: TemperatureUnit::Celsius },
     ///         Duration::from_secs(5),
     ///     )
     ///     .await?;


### PR DESCRIPTION
- Update Quick Start examples (sensor theme, fix compilability)
- Rename rabbitmq.sh -> amqp.sh (protocol-first naming convention)
- Fix stale math example references in lib.rs and doc comments
- Improve ARCHITECTURE.md: transport derivation lineage, EMBP link
- Fix feature flags table, remove misleading multi-transport note
- Update RabbitMQ expected output to match actual sensor output