### PR TITLE
refactor: rename Redis pubsub_sink/stream to subscribe_sink/stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Early versions may include intentional refactors as semantics are clarified.
 
 ---
 
+## [0.9.1] - 2026-03-07
+
+### Changed
+
+- Renamed Redis transport internal fields `pubsub_sink`/`pubsub_stream` → `subscribe_sink`/`subscribe_stream`
+  for naming consistency with `publish_conn` and clearer intent
+- Updated `docs/architecture.md`: added Redis `<details>` block consistent with MQTT, AMQP, and DDS sections
+- Updated `src/transport/redis/README.md`: field names and struct layout reflect rename
+- README prose and heading improvements (description, section titles, table alignment)
+- `scripts/sloc-count.sh`: fixed missing closing `*` in markdown footnote
+
+---
+
 ## [0.9.0] - 2026-02-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "mom-rpc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name          = "mom-rpc"
-version       = "0.9.0"
+version       = "0.9.1"
 edition       = "2021"
 authors       = ["John Basrai"]
-description   = "RPC abstraction for AMQP, DDS, MQTT, and Redis transports. Async request/response with automatic correlation handling."
+description   = "Async RPC over AMQP, DDS, MQTT, and Redis. Transport-agnostic — switch brokers via feature flags, not code."
 license       = "MIT OR Apache-2.0"
 repository    = "https://github.com/JohnBasrai/mom-rpc"
 rust-version  = "1.88" # Required by time crate (transitive dependency via lapin).

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@
 
 This crate provides a clean, strongly-typed RPC abstraction on top of pub/sub systems (such as MQTT or AMQP), without baking transport details into your application code.
 
-It is designed to *tame* message brokers, not expose them to application level code.
+It is designed to avoid exposing message broker details from application level code.
 
 ---
 
-## Lean by Design
+## Binary Footprint
 
 While this crate supports multiple transport implementations, **applications only compile the transports they enable**. The crate size shown on crates.io is the total of all transport implementations combined, but thanks to Cargo features, your application will only include the code for the transports you actually use. A typical application using a single transport will compile to approximately 45-55 KiB of mom-rpc code regardless of how many total transports the library supports.
 
 ---
 
-## Why this exists
+## Motivation
 
-Message-oriented middleware (pub/sub systems, etc.) is great for decoupling — but painful for request/response workflows:
+Message-oriented middleware (pub/sub systems, etc.) is great for decoupling — but insufficent for request/response workflows:
 
 * no native RPC semantics
 * no correlation handling
@@ -37,9 +37,9 @@ This crate solves that by providing:
 
 ---
 
-## How is this different?
+## Design Rationale
 
-Unlike RPC libraries that target a single broker, `mom-rpc` provides transport abstraction—write your RPC code once, run it on MQTT, AMQP, DDS, or in-memory. The same application works across different brokers by changing feature flags, not code. This matters when you need to deploy the same edge application across different infrastructure, or when your broker choice changes between development and production.
+Unlike RPC libraries that target a single broker, mom-rpc provides transport abstraction — write your RPC code once, run it on AMQP, DDS, MQTT, Redis, or in-memory by changing feature flags, not code. The same application works unchanged across development, staging, and production regardless of broker choice.
 
 ---
 
@@ -66,11 +66,11 @@ Unlike RPC libraries that target a single broker, `mom-rpc` provides transport a
 
 ---
 
-## Quick Start
+## Usage
 
 ### In-Memory Transport (Testing)
 
-Perfect for testing and single-process applications - no broker required:
+Suitable for testing and single-process applications - no broker required:
 
 ```rust
  use mom_rpc::{TransportBuilder, RpcBrokerBuilder, Result};
@@ -327,7 +327,7 @@ Broker-backed transports (e.g. MQTT) are implemented behind feature flags and ru
 
 `mom-rpc` provides multiple transport backends. Each is feature-gated so you only compile what you use:
 
-👉 The **memory transport is always available** - no feature flag required.
+The **memory transport is always available** - no feature flag required.
 
 **You can enable multiple transports and choose at runtime:**
 ```toml
@@ -350,19 +350,19 @@ The builder tries transports in this order: `dust_dds` → `rumqttc` → `lapin`
 
 Applications can also run multiple transports concurrently (e.g., MQTT for IoT devices and AMQP for backend services) by creating separate transport instances.
 
-**Transport implementation sizes (as of v0.9.0):**
+**Transport implementation sizes (as of v0.9.1):**
 
 
-| Transport | Feature Flag | SLOC | Use Case |
-|:----------|:-------------|-----:|:---------|
-| In-memory | *(always available)* | 107 | Testing, single-process |
-| AMQP      | `transport_lapin`    | 313 | RabbitMQ, enterprise messaging |
-| MQTT      | `transport_rumqttc`  | 418 | IoT, lightweight pub/sub |
-| DDS       | `transport_dust_dds` | 703 | Real-time, mission-critical |
-| Redis     | `transport_redis`    | 368 | In-memory pub/sub, low-latency messaging |
+| Transport | Feature Flag         | SLOC | Use Case                                 |
+|:----------|:---------------------|-----:|:-----------------------------------------|
+| In-memory | *(always available)* |  107 | Testing, single-process                  |
+| AMQP      | `transport_lapin`    |  313 | RabbitMQ, enterprise messaging           |
+| MQTT      | `transport_rumqttc`  |  418 | IoT, lightweight pub/sub                 |
+| DDS       | `transport_dust_dds` |  703 | Real-time, mission-critical              |
+| Redis     | `transport_redis`    |  368 | In-memory pub/sub, low-latency messaging |
 
 **Notes:**
- - *Core library: 1,402 lines, including In-memory.
+ - *Core library: 1,402 lines, including In-memory.*
  - *Total: 3,204 lines.*
  - *SLOC measured using `tokei` (crates.io methodology).*
 
@@ -375,7 +375,8 @@ With both MQTT and AMQP enabled: 1402 + 418 + 313 = 2133 lines.
 
 `request_total_timeout` is a **total wall-clock budget** for the entire request, including all retry attempts. It is distinct from `retry_max_delay`, which caps the interval between individual retries.
 
-The actual elapsed time may be less than the total timeout if the retry sequence exhausts its attempts first — whichever limit is reached first wins.
+The actual elapsed time may be less than the total timeout if the retry sequence exhausts its attempts first — the first limit reached takes precedence.
+
 
 Configure timeouts per-request or at the broker level:
 
@@ -434,7 +435,7 @@ See `examples/sensor_fullduplex.rs` for a complete full-duplex example.
 
 ---
 
-## What this crate is **not**
+## None-Goals
 
 This crate intentionally does **not** provide:
 
@@ -444,7 +445,7 @@ This crate intentionally does **not** provide:
 * broker configuration
 * distributed consensus
 
-This crate focuses narrowly on RPC semantics. It intentionally avoids higher-level distributed-systems concerns such as discovery, consensus, retries, or topology management. The underlying transport is expected to provide any required distributed-systems features.
+This crate focuses narrowly on RPC semantics. The underlying transport is expected to provide any required distributed-systems features.
 
 ---
 
@@ -517,14 +518,14 @@ This library does not handle authentication. Delegate to:
 - [Complete API reference on docs.rs](https://docs.rs/mom-rpc)
 - [Design patterns and module structure](docs/architecture.md)
 - [Development guide and standards](CONTRIBUTING.md)
-- [Release notes](https://github.com/JohnBasrai/mom-rpc/releases/tag/v0.9.0)
+- [Release notes](https://github.com/JohnBasrai/mom-rpc/releases/tag/v0.9.1)
 
 ---
 
 ## Status
 
 * Early development / API unstable
-* Feedback welcome via [GitHub issues](https://github.com/JohnBasrai/mom-rpc/issues)
+* Issues and contributions are tracked via [GitHub](https://github.com/JohnBasrai/mom-rpc/issues)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,16 +45,16 @@ The architecture follows an **Explicit Module Boundary Pattern (EMBP)** througho
    │  - Addressing               │
    └───────────────▲─────────────┘
                    │
-   ┌───────────────┴────────────────┐
-   │     Concrete Transports        │
-   │                                │
-   │  -  memory (reference)         │
-   │  -  AMQP   (lapin    )         │
-   │  -  DDS    (dust_dds )         │
-   │  -  MQTT   (rumqttc  )         │
-   │  -  REDIS  (redis    )         │
-   │  -   ⋮                         │
-   └────────────────────────────────┘
+   ┌───────────────┴─────────────┐
+   │     Concrete Transports     │
+   │                             │
+   │  -  memory (reference)      │
+   │  -  AMQP   (lapin    )      │
+   │  -  DDS    (dust_dds )      │
+   │  -  MQTT   (rumqttc  )      │
+   │  -  Redis  (redis-rs )      │
+   │  -   ...                    │
+   └─────────────────────────────┘
 ```
 
 Note: Each transport, other than memory, is feature-gated. Applications compile only what they use.
@@ -112,16 +112,19 @@ transport/
 ├── dds/
 │    ├── mod.rs
 │    └── dust_dds.rs      # DDS via dust_dds
-└── mqtt/
+├── mqtt/
+│   ├── mod.rs
+│   └── rumqttc.rs        # MQTT via rumqttc
+└── redis/
     ├── mod.rs
-    └── rumqttc.rs        # MQTT via rumqttc
+    └── redis.rs          # Redis via redis-rs
 ```
 
 Future additions follow this same pattern. There may be multiple libraries used for a given transport.
 
 
 ```
-└── mqtt/
+├── mqtt/
 │   ├── mod.rs
 │   ├── rumqttc.rs
 │   └── new-library-crate
@@ -275,6 +278,43 @@ This preserves safety while keeping the public `Transport` trait `Send + Sync`.
 * **Reliability**: `Reliable`    - Ensures delivery with retries
 * **History**:     `KeepLast(1)` - Prevents correlation confusion
 * **Durability**:  `Volatile`    - No persistence, ephemeral messages
+
+</details>
+
+<details>
+<summary><strong>Redis Transport (Redis Pub/Sub)</strong></summary>
+
+The `redis` transport adapts Redis Pub/Sub semantics to the transport contract defined by this crate.
+
+### Concurrency model
+
+* A single background actor owns both Redis connections
+* All interaction with Redis is serialized through the actor
+* No other task touches the connections directly
+
+This preserves safety while keeping the public `Transport` trait `Send + Sync`.
+
+### Connection behavior
+
+* Two connections are required per transport instance: Redis prohibits issuing regular commands (e.g. `PUBLISH`) on a connection in Pub/Sub mode
+  * `publish_conn` — standard async connection, used exclusively for `PUBLISH`
+  * `subscribe_conn` — Pub/Sub connection, used only for `SUBSCRIBE` and inbound message delivery
+* Connections are established eagerly during transport creation
+* On connection error, the actor reconnects after a delay and re-subscribes to all active topics
+
+### Subscription semantics
+
+* Subscriptions are serialized one at a time via an `Ack::Retry` pattern
+* Redis sends a confirmation on `SUBSCRIBE` that contains no topic name, making concurrent subscribes ambiguous
+* If a subscribe is already in flight, the actor responds `Ack::Retry` and the caller sleeps briefly before retrying
+* This serializes subscribes without blocking the actor event loop
+
+### Message delivery
+
+* Incoming Pub/Sub messages are demultiplexed by topic
+* Messages are fanned out to all local subscribers for that topic
+* Delivery is best-effort and non-durable
+* No retained-message or replay behavior
 
 </details>
 
@@ -441,7 +481,7 @@ It provides a **clean RPC abstraction over imperfect transports**, not a perfect
 
 Potential future extensions include:
 
-* Additional transport implementations
+* Additional transport implementations such as `fred` as a second library for `Redis`
 * Optional response caching for idempotent requests
 * Pluggable retry / timeout policies
 

--- a/docs/contributing/ARCHITECTURE.md
+++ b/docs/contributing/ARCHITECTURE.md
@@ -35,7 +35,7 @@ src
     ├── dds              # DDS protocol transports
     │   ├── mod.rs       # Protocol gateway (EMBP)
     │   ├── dust_dds.rs  # DDS via dust_dds library
-    │   └── README.md    # DDS design notes
+    │   └── README.md    # DDS detail design notes
     ├── memory.rs        # In-memory transport (always available)
     ├── mqtt             # MQTT protocol transports
     │   ├── mod.rs       # Protocol gateway (EMBP)
@@ -43,7 +43,7 @@ src
     └── redis            # Redis protocol transports
         ├── mod.rs       # Protocol gateway (EMBP)
         ├── redis.rs     # Redis Pub/Sub via redis library
-        └── README.md    # Redis transport design notes
+        └── README.md    # Redis transport detail design notes
 
 ```
 

--- a/scripts/sloc-count.sh
+++ b/scripts/sloc-count.sh
@@ -40,7 +40,7 @@ total=$(tokei src/ --output json | jq '.Rust.code')
 core=$((total - amqp_sloc - mqtt_sloc - dds_sloc - redis_sloc))
 
 echo "**Notes:**"
-echo " - *Core library: $core lines, including In-memory."
+echo " - *Core library: $core lines, including In-memory.*"
 echo " - *Total: $total lines.*"
 echo " - *SLOC measured using \`tokei\` (crates.io methodology).*"
 echo

--- a/src/transport/redis/README.md
+++ b/src/transport/redis/README.md
@@ -106,8 +106,8 @@ Redis **requires a dedicated connection** for Pub/Sub — a connection in
 Pub/Sub mode cannot issue regular commands like `PUBLISH`. Two async
 connections are required:
 
-- `publish_conn` — regular `redis::aio::Connection`, used only for `PUBLISH`
-- `pubsub_conn` — `redis::aio::PubSub` connection, used for `SUBSCRIBE`
+- `publish_conn`   — `redis::aio::Connection`, used only for `PUBLISH`
+- `subscribe_conn` — `redis::aio::PubSub` connection, used for `SUBSCRIBE`
   and receiving incoming messages
 
 `publish_conn` is used imperatively inside the `Cmd::Publish` arm — awaited
@@ -138,7 +138,7 @@ loop {
             }
         }
 
-        msg = self.pubsub_conn.on_message() => {
+        msg = self.subscribe_conn.on_message() => {
             // Deserialize envelope, fan out to local subscribers
             Self::handle_incoming(
                 self.transport_id.clone(),
@@ -154,11 +154,11 @@ loop {
 }
 ```
 
-| select! arm | Connection used | Purpose |
-|-------------|----------------|---------|
-| `cmd_rx.recv()` | `publish_conn` (inline) | Application commands |
-| `pubsub_conn.on_message()` | `pubsub_conn` | Incoming broker messages → fanout |
-| `shutdown.notified()` | — | Clean teardown |
+| select! arm                   | Connection used  | Purpose                           |
+|-------------------------------|------------------|-----------------------------------|
+| `cmd_rx.recv()`               | `publish_conn`   | Application commands              |
+| `subscribe_conn.on_message()` | `subscribe_conn` | Incoming broker messages → fanout |
+| `shutdown.notified()`         | —                | Clean teardown                    |
 
 ---
 
@@ -217,7 +217,7 @@ pub struct RedisTransport {
 struct RedisActor {
     transport_id: String,
     publish_conn: redis::aio::Connection,
-    pubsub_conn: redis::aio::PubSub,
+    subscribe_conn: redis::aio::PubSub,
     cmd_rx: mpsc::Receiver<Cmd>,
     subscribers: SubscriberMap,
     pending_subscribe: PendingSubscribe,

--- a/src/transport/redis/redis.rs
+++ b/src/transport/redis/redis.rs
@@ -9,8 +9,8 @@
 //! - A single background **actor task** owns both Redis connections.
 //! - The actor is responsible for:
 //!   - publishing outbound messages via `publish_conn`,
-//!   - registering broker subscriptions via `pubsub_sink`,
-//!   - polling `pubsub_stream` for incoming data messages,
+//!   - registering broker subscriptions via `subscribe_sink`,
+//!   - polling `subscribe_stream` for incoming data messages,
 //!   - clean shutdown of both connections.
 //! - All interaction with the Redis client is serialized through this actor;
 //!   no other task ever touches the connections directly.
@@ -22,11 +22,11 @@
 //! connections are therefore maintained:
 //!
 //! - `publish_conn` — `MultiplexedConnection`, used only for `PUBLISH`
-//! - `pubsub_sink` / `pubsub_stream` — split from `aio::PubSub`, used for
+//! - `subscribe_sink` / `subscribe_stream` — split from `aio::PubSub`, used for
 //!   `SUBSCRIBE` and receiving incoming messages respectively
 //!
-//! `split()` is used so that `pubsub_sink` can call `subscribe()` concurrently
-//! with `pubsub_stream` being polled in `select!`.
+//! `split()` is used so that `subscribe_sink` can call `subscribe()` concurrently
+//! with `subscribe_stream` being polled in `select!`.
 //!
 //! ## Subscription confirmation
 //!
@@ -173,8 +173,8 @@ impl RedisTransport {
     pub fn create(
         base: TransportBase,
         publish_conn: MultiplexedConnection,
-        pubsub_sink: PubSubSink,
-        pubsub_stream: PubSubStream,
+        subscribe_sink: PubSubSink,
+        subscribe_stream: PubSubStream,
         shutdown: Arc<Notify>,
     ) -> TransportPtr {
         // ---
@@ -187,8 +187,8 @@ impl RedisTransport {
         let actor = RedisActor {
             transport_id: base.transport_id.clone(),
             publish_conn,
-            pubsub_sink,
-            pubsub_stream,
+            subscribe_sink,
+            subscribe_stream,
             cmd_rx,
             subscribers: Arc::clone(&subscribers),
             subscribe_pending,
@@ -216,8 +216,8 @@ struct RedisActor {
     // ---
     transport_id: String, // for logging only
     publish_conn: MultiplexedConnection,
-    pubsub_sink: PubSubSink,
-    pubsub_stream: PubSubStream,
+    subscribe_sink: PubSubSink,
+    subscribe_stream: PubSubStream,
     cmd_rx: mpsc::Receiver<Cmd>,
     subscribers: SubscriberMap,
     subscribe_pending: PendingSubscribe,
@@ -244,7 +244,7 @@ impl RedisActor {
                     }
                 }
 
-                maybe_msg = self.pubsub_stream.next() => {
+                maybe_msg = self.subscribe_stream.next() => {
                     match maybe_msg {
                         Some(msg) => {
                             let transport_id = self.transport_id.clone();
@@ -252,8 +252,8 @@ impl RedisActor {
                             Self::handle_incoming(transport_id, subscribers, msg).await;
                         }
                         None => {
-                            // pubsub_stream terminated (connection lost)
-                            log_error!("{}: pubsub stream ended", self.transport_id);
+                            // subscribe_stream terminated (connection lost)
+                            log_error!("{}: subscribe stream ended", self.transport_id);
                             self.reconnect = true;
                             tokio::time::sleep(RECONNECT_DELAY).await;
                         }
@@ -328,7 +328,7 @@ impl RedisActor {
             *pending = true;
         }
 
-        let result = self.pubsub_sink.subscribe(&topic).await;
+        let result = self.subscribe_sink.subscribe(&topic).await;
 
         {
             let mut pending = self.subscribe_pending.write().await;
@@ -541,7 +541,7 @@ pub async fn create_transport(config: TransportConfig) -> Result<TransportPtr> {
             RpcError::Transport(msg)
         })?;
 
-    let (pubsub_sink, pubsub_stream) = client
+    let (subscribe_sink, subscribe_stream) = client
         .get_async_pubsub()
         .await
         .map_err(|err| {
@@ -558,8 +558,8 @@ pub async fn create_transport(config: TransportConfig) -> Result<TransportPtr> {
     Ok(RedisTransport::create(
         TransportBase::from(&config),
         publish_conn,
-        pubsub_sink,
-        pubsub_stream,
+        subscribe_sink,
+        subscribe_stream,
         shutdown,
     ))
 }


### PR DESCRIPTION
Renames internal Redis actor fields for naming consistency:
- pubsub_sink   → subscribe_sink
- pubsub_stream → subscribe_stream

These names better reflect mom-rpc's perspective (subscribe/publish)
rather than the redis crate's internal Pub/Sub mode terminology.

Also includes:
- docs/architecture.md: added Redis <details> block
- src/transport/redis/README.md: updated field names and struct layout
- README.md: prose and heading cleanup
- scripts/sloc-count.sh: fix missing closing * in markdown footnote
- Correct Redis capitalization and remove redundant prefix in README table
- Update description in Cargo.toml