### PR TITLE
chore: bump redis, anyhow, and lapin dependencies (0.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Early versions may include intentional refactors as semantics are clarified.
 
 ---
 
+## [0.9.2] - 2026-03-07
+
+### Dependencies
+
+- `redis`  1.0.3 → 1.0.4
+- `anyhow` 1.0.101 → 1.0.102
+- `lapin`  4.0.0 → 4.2.0 (adds tokio integration; transitive: `amq-protocol` 10.0.0 → 10.0.1, `tokio` 1.49 → 1.50)
+
+All transports tested against live brokers.
+
+---
+
 ## [0.9.1] - 2026-03-07
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e969d1d702793536d5fda739a82b88ad7cbe7d04f8386ee8cd16ad3eff4854a5"
+checksum = "dbe7f6e08ce1c6a9b21684e643926f6fc3b683bc006cb89afd72a5e0eb16e3a2"
 dependencies = [
  "arcstr",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol"
-version = "10.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee97af9a24cdc2c69f98d2464788a266cf6a1dcea8608abc65509b56c081861"
+checksum = "8032525e9bb1bb8aa556476de729106e972b9fb811e5db21ce462a4f0f057d03"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "10.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c354caa094fe66a9ece3ed1e0360610cc02f10d34756e921cdd6a67ca6a1a9ea"
+checksum = "22f50ebc589843a42a1428b3e1b149164645bfe8c22a7ed0f128ad0af4aaad84"
 dependencies = [
  "amq-protocol-uri",
  "async-rs",
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "10.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f447aeb3add041a565fd18d111c3ab3633b1a5c88fb7aaf5d47e6f32f1d41a8"
+checksum = "12ffea0c942eb17ea55262e4cc57b223d8d6f896269b1313153f9215784dc2b8"
 dependencies = [
  "cookie-factory",
  "nom 8.0.0",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "10.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addb88dcc95c68ee67cac58552a7203f7b7845a30d28fcde485c2f8be834953b"
+checksum = "baa9f65c896cb658503e5547e262132ac356c26bc477afedfd8d3f324f4c5006"
 dependencies = [
  "amq-protocol-types",
  "percent-encoding",
@@ -1135,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a141b8c334a9b2348b7b2afc9f0f2924ae9f76b1bead880daa9c93bf2a5fd7"
+checksum = "a8decd7bf1a850e52f80cc5dd8815bad9d5ab07859a918ab660dd1f5f03e9021"
 dependencies = [
  "amq-protocol",
  "async-rs",
@@ -1147,6 +1147,7 @@ dependencies = [
  "flume 0.12.0",
  "futures-core",
  "futures-io",
+ "tokio",
  "tracing",
 ]
 
@@ -2052,9 +2053,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tcp-stream"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232266a1fa32dc0e183eb5337962701be17495e98401a0ce10f1a6951d8f8963"
+checksum = "228ee8f41fd20e97f2af4afdd54901b1711aef9d49136d8d6c53f10f4416a4cb"
 dependencies = [
  "async-rs",
  "cfg-if",
@@ -2170,9 +2171,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "mom-rpc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arcstr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "mom-rpc"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 authors       = ["John Basrai"]
 description   = "Async RPC over AMQP, DDS, MQTT, and Redis. Transport-agnostic — switch brokers via feature flags, not code."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = { version = "0.3", optional = true }
 futures      = { version = "0.3", optional = true } # For DDS
 futures-lite = { version = "2", optional = true }
 lapin        = { version = "4", optional = true }
-redis        = { version = "^1.0.3", features = ["tokio-comp", "aio"], optional = true }
+redis        = { version = "^1.0.4", features = ["tokio-comp", "aio"], optional = true }
 rumqttc      = { version = "0.25", optional = true }
 serde        = { version = "1", features = ["derive", "rc"] }
 serde_json   = "1"

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ The builder tries transports in this order: `dust_dds` → `rumqttc` → `lapin`
 
 Applications can also run multiple transports concurrently (e.g., MQTT for IoT devices and AMQP for backend services) by creating separate transport instances.
 
-**Transport implementation sizes (as of v0.9.1):**
+**Transport implementation sizes (as of v0.9.2):**
 
 
 | Transport | Feature Flag         | SLOC | Use Case                                 |
@@ -518,7 +518,7 @@ This library does not handle authentication. Delegate to:
 - [Complete API reference on docs.rs](https://docs.rs/mom-rpc)
 - [Design patterns and module structure](docs/architecture.md)
 - [Development guide and standards](CONTRIBUTING.md)
-- [Release notes](https://github.com/JohnBasrai/mom-rpc/releases/tag/v0.9.1)
+- [Release notes](https://github.com/JohnBasrai/mom-rpc/releases/tag/v0.9.2)
 
 ---
 


### PR DESCRIPTION
Merges three Dependabot dependency updates, all tested:

- redis 1.0.3 → 1.0.4
- anyhow 1.0.101 → 1.0.102
- lapin 4.0.0 → 4.2.0 (includes tokio 1.49 → 1.50, amq-protocol 10.0.0 → 10.0.1)

All unit tests and manual integration tests (AMQP, MQTT, DDS, Redis) pass.