### PR TITLE
chore: migrate to Rust edition 2024

### DIFF
--- a/src/transport/mqtt/rumqttc.rs
+++ b/src/transport/mqtt/rumqttc.rs
@@ -271,11 +271,11 @@ impl MqttActor {
                                 };
 
                                 for topic in topics {
-                                    if let Err(err) = self.client.subscribe(&topic, QoS::AtMostOnce).await {
+                                    match self.client.subscribe(&topic, QoS::AtMostOnce).await { Err(err) => {
                                         log_error!("{}: resubscribe failed for {topic}: {err}", self.transport_id);
-                                    } else {
+                                    } _ => {
                                         log_info!("{}: resubscribed to {topic}", self.transport_id);
-                                    }
+                                    }}
                                 }
                             }
                         }


### PR DESCRIPTION
One auto-fix in rumqttc.rs, drop-order warning in broker.rs reviewed and confirmed harmless.