### PR TITLE
Fix/dust dds 0.15 api to address (RUSTSEC-2026-0119/0120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -608,11 +608,11 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust_dds"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c41e5b28f155aec2860a5485db193485e57649bfce59258aa02e8b4e93f778"
+checksum = "f0a1a8670f436a711942d5218b2ef20aa579e8745a9912721de540e5a2e29dae"
 dependencies = [
- "async-lock",
+ "critical-section",
  "dust_dds_derive",
  "md5",
  "network-interface",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "dust_dds_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad07e59a9f8ff513bba952dfa82c4667e6162ba5b1e159e020845eded535b489"
+checksum = "56b01180d953c1a42e2e0b556daf15fde64d84daf836834457de949fcbddece2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -916,7 +916,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -937,7 +937,7 @@ dependencies = [
  "prefix-trie",
  "rand",
  "ring",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "url",
@@ -964,7 +964,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -1149,7 +1149,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -1332,7 +1332,7 @@ dependencies = [
  "rumqttc",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1348,13 +1348,13 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "network-interface"
-version = "1.1.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+checksum = "4ddcb8865ad3d9950f22f42ffa0ef0aecbfbf191867b3122413602b0a360b2a6"
 dependencies = [
  "cc",
  "libc",
- "thiserror 1.0.69",
+ "thiserror",
  "winapi",
 ]
 
@@ -1464,7 +1464,7 @@ dependencies = [
  "rc2",
  "sha1",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "x509-parser",
 ]
 
@@ -1762,7 +1762,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-webpki 0.102.8",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -2221,31 +2221,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2923,7 +2903,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,9 +901,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ include       = [
 [dependencies]
 async-trait  = "0.1"
 bytes        = { version = "1", features = ["serde"] }
-dust_dds     = { version = "0.14", features = ["dcps"], optional = true }
+dust_dds     = { version = "0.15", features = ["dcps"], optional = true }
 futures-util = { version = "0.3", optional = true }
 futures-lite = { version = "2", optional = true }
 lapin        = { version = "4", optional = true }

--- a/src/transport/dds/dust_dds.rs
+++ b/src/transport/dds/dust_dds.rs
@@ -78,7 +78,6 @@ use dust_dds::{
         time::{Duration as DdsDuration, DurationKind},
         type_support::DdsType,
     },
-    std_runtime::StdRuntime,
 };
 
 use std::collections::HashMap;
@@ -256,10 +255,7 @@ impl DustddsTransport {
     // ---
 
     /// Creates a new dust_dds transport with the given `DomainParticipant`.
-    pub fn create(
-        base: TransportBase,
-        participant: DomainParticipantAsync<StdRuntime>,
-    ) -> TransportPtr {
+    pub fn create(base: TransportBase, participant: DomainParticipantAsync) -> TransportPtr {
         // ---
 
         let transport_id = base.transport_id.clone();
@@ -299,11 +295,11 @@ impl DustddsTransport {
 struct DdsActor {
     // ---
     transport_id: String, // for logging only
-    participant: DomainParticipantAsync<StdRuntime>,
+    participant: DomainParticipantAsync,
     cmd_rx: mpsc::Receiver<Cmd>,
     subscribers: SubscriberMap,
     shutdown_tx: watch::Sender<bool>,
-    writers: HashMap<String, DataWriterAsync<StdRuntime, DdsEnvelope>>,
+    writers: HashMap<String, DataWriterAsync<DdsEnvelope>>,
     reader_tasks: Vec<JoinHandle<()>>,
 }
 
@@ -506,7 +502,7 @@ impl DdsActor {
 async fn run_topic_reader(
     transport_id: String,
     topic: String,
-    reader: DataReaderAsync<StdRuntime, DdsEnvelope>,
+    reader: DataReaderAsync<DdsEnvelope>,
     subscribers: SubscriberMap,
     mut shutdown_rx: watch::Receiver<bool>,
 ) {
@@ -532,9 +528,6 @@ async fn run_topic_reader(
         return;
     }
 
-    // NOTE: This is DDS timeout/duration. It is not not std or tokio versions.
-    let one_day = DdsDuration::new(86400, 0);
-
     loop {
         tokio::select! {
             _ = shutdown_rx.changed() => {
@@ -542,7 +535,7 @@ async fn run_topic_reader(
                 break;
             }
 
-            res = waitset.wait(one_day) => {
+            res = waitset.wait() => {
                 let triggered = match res {
                     Ok(v) => v,
                     Err(e) => {
@@ -575,7 +568,7 @@ async fn run_topic_reader(
 async fn drain_reader(
     transport_id: &str,
     topic: &str,
-    reader: &DataReaderAsync<StdRuntime, DdsEnvelope>,
+    reader: &DataReaderAsync<DdsEnvelope>,
     subscribers: &SubscriberMap,
 ) -> Result<()> {
     // ---
@@ -917,7 +910,7 @@ fn parse_domain_id(uri: Option<&str>) -> Result<u16> {
 async fn wait_for_matched_reader(
     tid: &str,
     topic: &str,
-    writer: &DataWriterAsync<StdRuntime, DdsEnvelope>,
+    writer: &DataWriterAsync<DdsEnvelope>,
     timeout_secs: u64,
 ) -> Result<()> {
     // ---
@@ -948,14 +941,15 @@ async fn wait_for_matched_reader(
         .await
         .map_err(|e| RpcError::Transport(format!("attach_condition failed: {e:?}")))?;
 
-    let timeout = DdsDuration::new(timeout_secs as i32, 0);
-
     // Wait for publication match
-    waitset.wait(timeout).await.map_err(|e| {
-        RpcError::Transport(format!(
-            "{tid}: no matched readers for topic {topic} within {timeout_secs}s: {e:?}"
-        ))
-    })?;
+    tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), waitset.wait())
+        .await
+        .map_err(|_| {
+            RpcError::Transport(format!(
+                "{tid}: no matched readers for topic {topic} within {timeout_secs}s"
+            ))
+        })?
+        .map_err(|e| RpcError::Transport(format!("{tid}: waitset.wait failed: {e:?}")))?;
 
     // Verify we actually have a match
     let status = writer.get_publication_matched_status().await.map_err(|e| {


### PR DESCRIPTION
 chore: bump hickory-{net,proto,resolver} to 0.26.1 (RUSTSEC-2026-0119/0120)
    
Fixes two CVEs in transitive hickory-dns dependencies:
   - RUSTSEC-2026-0119: CPU exhaustion O(n²) name compression (hickory-proto)
   - RUSTSEC-2026-0120: NSEC3 unbounded loop on cross-zone responses (hickory-net)
